### PR TITLE
fix: use numeric uid for threads image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /app
 
 COPY --from=build /out/threads /app/threads
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -g 65532 -S app && adduser -u 65532 -S app -G app
 
-USER app
+USER 65532
 
 ENTRYPOINT ["/app/threads"]


### PR DESCRIPTION
## Summary
- set the runtime user to UID 65532 to satisfy runAsNonRoot
- align user/group creation with numeric UID

## Testing
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go build ./...
- helm dependency build charts/threads && helm lint charts/threads

## Issue
- #9