### PR TITLE
fix: default service addresses

### DIFF
--- a/charts/threads/values.yaml
+++ b/charts/threads/values.yaml
@@ -75,11 +75,11 @@ env:
   - name: DATABASE_URL
     value: ""
   - name: NOTIFICATIONS_ADDRESS
-    value: ""
+    value: "notifications:50051"
   - name: IDENTITY_ADDRESS
-    value: ""
+    value: "identity:50051"
   - name: AUTHORIZATION_ADDRESS
-    value: ""
+    value: "authorization:50051"
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,15 +25,15 @@ func FromEnv() (Config, error) {
 	}
 	cfg.NotificationsAddress = os.Getenv("NOTIFICATIONS_ADDRESS")
 	if cfg.NotificationsAddress == "" {
-		cfg.NotificationsAddress = "notifications:50051"
+		return Config{}, fmt.Errorf("NOTIFICATIONS_ADDRESS must be set")
 	}
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
-		cfg.IdentityAddress = "identity:50051"
+		return Config{}, fmt.Errorf("IDENTITY_ADDRESS must be set")
 	}
 	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
 	if cfg.AuthorizationAddress == "" {
-		cfg.AuthorizationAddress = "authorization:50051"
+		return Config{}, fmt.Errorf("AUTHORIZATION_ADDRESS must be set")
 	}
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,15 +25,15 @@ func FromEnv() (Config, error) {
 	}
 	cfg.NotificationsAddress = os.Getenv("NOTIFICATIONS_ADDRESS")
 	if cfg.NotificationsAddress == "" {
-		return Config{}, fmt.Errorf("NOTIFICATIONS_ADDRESS must be set")
+		cfg.NotificationsAddress = "notifications:50051"
 	}
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
-		return Config{}, fmt.Errorf("IDENTITY_ADDRESS must be set")
+		cfg.IdentityAddress = "identity:50051"
 	}
 	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
 	if cfg.AuthorizationAddress == "" {
-		return Config{}, fmt.Errorf("AUTHORIZATION_ADDRESS must be set")
+		cfg.AuthorizationAddress = "authorization:50051"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary
- default notifications/identity/authorization addresses in config
- set chart env defaults for service addresses

## Testing
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go build ./...
- helm dependency build charts/threads && helm lint charts/threads

## Issue
- #9