### PR TITLE
Add passive participants and nickname resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1
 
       - name: Run tests
         run: go test ./...

--- a/charts/threads/values.yaml
+++ b/charts/threads/values.yaml
@@ -76,6 +76,8 @@ env:
     value: ""
   - name: NOTIFICATIONS_ADDRESS
     value: ""
+  - name: IDENTITY_ADDRESS
+    value: ""
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/cmd/threads/main.go
+++ b/cmd/threads/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	notificationsv1 "github.com/agynio/threads/.gen/go/agynio/api/notifications/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -58,10 +59,20 @@ func run() error {
 	}
 	defer notificationsConn.Close()
 
+	identityConn, err := grpc.DialContext(ctx, cfg.IdentityAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial identity: %w", err)
+	}
+	defer identityConn.Close()
+
 	threadsServer := grpc.NewServer()
 	threadsv1.RegisterThreadsServiceServer(
 		threadsServer,
-		server.New(store.NewStore(pool), notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn))),
+		server.New(
+			store.NewStore(pool),
+			notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
+			identityv1.NewIdentityServiceClient(identityConn),
+		),
 	)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1
+                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1
                   exec go run ./cmd/threads
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=threads-e2e" \
         -n ${THREADS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	GRPCAddress          string
 	DatabaseURL          string
 	NotificationsAddress string
+	IdentityAddress      string
 }
 
 func FromEnv() (Config, error) {
@@ -24,6 +25,10 @@ func FromEnv() (Config, error) {
 	cfg.NotificationsAddress = os.Getenv("NOTIFICATIONS_ADDRESS")
 	if cfg.NotificationsAddress == "" {
 		return Config{}, fmt.Errorf("NOTIFICATIONS_ADDRESS must be set")
+	}
+	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
+	if cfg.IdentityAddress == "" {
+		return Config{}, fmt.Errorf("IDENTITY_ADDRESS must be set")
 	}
 	return cfg, nil
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -20,6 +20,7 @@ func toProtoThread(thread store.Thread) *threadsv1.Thread {
 			protoThread.Participants[i] = &threadsv1.Participant{
 				Id:       participant.ID.String(),
 				JoinedAt: timestamppb.New(participant.JoinedAt),
+				Passive:  participant.Passive,
 			}
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -16,12 +18,28 @@ import (
 
 type Server struct {
 	threadsv1.UnimplementedThreadsServiceServer
-	store    *store.Store
+	store    threadStore
 	notifier *notifier.Notifier
+	identity identityResolver
 }
 
-func New(store *store.Store, notifier *notifier.Notifier) *Server {
-	return &Server{store: store, notifier: notifier}
+type threadStore interface {
+	CreateThread(ctx context.Context, participantIDs []uuid.UUID) (store.Thread, error)
+	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
+	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
+	ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *store.ThreadCursor) (store.ThreadListResult, error)
+	ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
+	ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
+	AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
+}
+
+type identityResolver interface {
+	ResolveNickname(ctx context.Context, in *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
+}
+
+func New(store threadStore, notifier *notifier.Notifier, identity identityResolver) *Server {
+	return &Server{store: store, notifier: notifier, identity: identity}
 }
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
@@ -67,11 +85,11 @@ func (s *Server) AddParticipant(ctx context.Context, req *threadsv1.AddParticipa
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
 	}
-	participantID, err := parseUUID(req.GetParticipantId())
+	participantID, err := s.resolveParticipantID(ctx, req)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "participant_id: %v", err)
+		return nil, err
 	}
-	thread, err := s.store.AddParticipant(ctx, threadID, participantID)
+	thread, err := s.store.AddParticipant(ctx, threadID, participantID, req.GetPassive())
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -184,6 +202,14 @@ func (s *Server) GetUnackedMessages(ctx context.Context, req *threadsv1.GetUnack
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "participant_id: %v", err)
 	}
+	var threadID *uuid.UUID
+	if req.ThreadId != nil {
+		parsedID, err := parseUUID(req.GetThreadId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
+		}
+		threadID = &parsedID
+	}
 	var cursor *store.MessageCursor
 	if token := req.GetPageToken(); token != "" {
 		tokenID, tokenCursor, err := store.DecodeUnackedMessagePageToken(token)
@@ -196,7 +222,7 @@ func (s *Server) GetUnackedMessages(ctx context.Context, req *threadsv1.GetUnack
 		cursor = &tokenCursor
 	}
 
-	result, err := s.store.ListUnackedMessages(ctx, participantID, req.GetPageSize(), cursor)
+	result, err := s.store.ListUnackedMessages(ctx, participantID, threadID, req.GetPageSize(), cursor)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -236,6 +262,53 @@ func (s *Server) AckMessages(ctx context.Context, req *threadsv1.AckMessagesRequ
 		return nil, toStatusError(err)
 	}
 	return &threadsv1.AckMessagesResponse{AckedCount: count}, nil
+}
+
+func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
+	if req.GetParticipant() == nil {
+		participantID, err := parseUUID(req.GetParticipantId())
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "participant_id: %v", err)
+		}
+		return participantID, nil
+	}
+	identifier := req.GetParticipant().GetIdentifier()
+	switch value := identifier.(type) {
+	case *threadsv1.ParticipantIdentifier_ParticipantId:
+		participantID, err := parseUUID(value.ParticipantId)
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "participant.participant_id: %v", err)
+		}
+		return participantID, nil
+	case *threadsv1.ParticipantIdentifier_ParticipantNickname:
+		if req.OrganizationId == nil {
+			return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+		}
+		if value.ParticipantNickname == "" {
+			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
+		}
+		organizationID, err := parseUUID(req.GetOrganizationId())
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		if s.identity == nil {
+			return uuid.UUID{}, status.Error(codes.Internal, "identity client is unavailable")
+		}
+		response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
+			OrganizationId: organizationID.String(),
+			Nickname:       value.ParticipantNickname,
+		})
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname: %v", err)
+		}
+		participantID, err := parseUUID(response.GetIdentityId())
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname identity_id: %v", err)
+		}
+		return participantID, nil
+	default:
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
+	}
 }
 
 func parseUUID(value string) (uuid.UUID, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,14 +12,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/agynio/threads/internal/notifier"
 	"github.com/agynio/threads/internal/store"
 )
 
 type Server struct {
 	threadsv1.UnimplementedThreadsServiceServer
 	store    threadStore
-	notifier *notifier.Notifier
+	notifier notifierPublisher
 	identity identityResolver
 }
 
@@ -38,7 +37,11 @@ type identityResolver interface {
 	ResolveNickname(ctx context.Context, in *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
 }
 
-func New(store threadStore, notifier *notifier.Notifier, identity identityResolver) *Server {
+type notifierPublisher interface {
+	PublishMessageCreated(ctx context.Context, threadID, messageID uuid.UUID, recipients []uuid.UUID) error
+}
+
+func New(store threadStore, notifier notifierPublisher, identity identityResolver) *Server {
 	return &Server{store: store, notifier: notifier, identity: identity}
 }
 
@@ -290,9 +293,6 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 		organizationID, err := parseUUID(req.GetOrganizationId())
 		if err != nil {
 			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		if s.identity == nil {
-			return uuid.UUID{}, status.Error(codes.Internal, "identity client is unavailable")
 		}
 		response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
 			OrganizationId: organizationID.String(),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
+	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+
+	"github.com/agynio/threads/internal/store"
+)
+
+type fakeThreadStore struct {
+	t                     *testing.T
+	expectedThreadID      uuid.UUID
+	expectedParticipantID uuid.UUID
+	expectedPassive       bool
+	called                bool
+	thread                store.Thread
+}
+
+func (f *fakeThreadStore) CreateThread(context.Context, []uuid.UUID) (store.Thread, error) {
+	panic("unexpected CreateThread call")
+}
+
+func (f *fakeThreadStore) ArchiveThread(context.Context, uuid.UUID) (store.Thread, error) {
+	panic("unexpected ArchiveThread call")
+}
+
+func (f *fakeThreadStore) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error) {
+	f.t.Helper()
+	f.called = true
+	if threadID != f.expectedThreadID {
+		f.t.Fatalf("expected thread ID %s, got %s", f.expectedThreadID, threadID)
+	}
+	if participantID != f.expectedParticipantID {
+		f.t.Fatalf("expected participant ID %s, got %s", f.expectedParticipantID, participantID)
+	}
+	if passive != f.expectedPassive {
+		f.t.Fatalf("expected passive %v, got %v", f.expectedPassive, passive)
+	}
+	return f.thread, nil
+}
+
+func (f *fakeThreadStore) SendMessage(context.Context, uuid.UUID, uuid.UUID, string, []uuid.UUID) (store.SendMessageResult, error) {
+	panic("unexpected SendMessage call")
+}
+
+func (f *fakeThreadStore) ListThreads(context.Context, uuid.UUID, int32, *store.ThreadCursor) (store.ThreadListResult, error) {
+	panic("unexpected ListThreads call")
+}
+
+func (f *fakeThreadStore) ListMessages(context.Context, uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
+	panic("unexpected ListMessages call")
+}
+
+func (f *fakeThreadStore) ListUnackedMessages(context.Context, uuid.UUID, *uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
+	panic("unexpected ListUnackedMessages call")
+}
+
+func (f *fakeThreadStore) AckMessages(context.Context, uuid.UUID, []uuid.UUID) (int32, error) {
+	panic("unexpected AckMessages call")
+}
+
+type fakeIdentityResolver struct {
+	t                *testing.T
+	expectedOrgID    string
+	expectedNickname string
+	responseID       string
+	called           bool
+}
+
+func (f *fakeIdentityResolver) ResolveNickname(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+	f.t.Helper()
+	f.called = true
+	if req.GetOrganizationId() != f.expectedOrgID {
+		f.t.Fatalf("expected organization ID %s, got %s", f.expectedOrgID, req.GetOrganizationId())
+	}
+	if req.GetNickname() != f.expectedNickname {
+		f.t.Fatalf("expected nickname %s, got %s", f.expectedNickname, req.GetNickname())
+	}
+	return &identityv1.ResolveNicknameResponse{IdentityId: f.responseID}, nil
+}
+
+func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+
+	storeStub := &fakeThreadStore{
+		t:                     t,
+		expectedThreadID:      threadID,
+		expectedParticipantID: participantID,
+		expectedPassive:       true,
+		thread: store.Thread{
+			ID:        threadID,
+			Status:    store.ThreadStatusActive,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Participants: []store.Participant{
+				{ID: participantID, JoinedAt: now, Passive: true},
+			},
+		},
+	}
+	identityStub := &fakeIdentityResolver{
+		t:                t,
+		expectedOrgID:    organizationID.String(),
+		expectedNickname: "agent-alpha",
+		responseID:       participantID.String(),
+	}
+
+	srv := New(storeStub, nil, identityStub)
+	orgIDValue := organizationID.String()
+	resp, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+		ThreadId:       threadID.String(),
+		OrganizationId: &orgIDValue,
+		Passive:        true,
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "agent-alpha"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeStub.called {
+		t.Fatal("expected AddParticipant to be called")
+	}
+	if !identityStub.called {
+		t.Fatal("expected ResolveNickname to be called")
+	}
+	if resp.GetThread() == nil || len(resp.GetThread().GetParticipants()) != 1 {
+		t.Fatalf("expected 1 participant, got %v", resp.GetThread().GetParticipants())
+	}
+	if !resp.GetThread().GetParticipants()[0].GetPassive() {
+		t.Fatal("expected passive participant to be true")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,80 +9,76 @@ import (
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/agynio/threads/internal/store"
 )
 
-type fakeThreadStore struct {
-	t                     *testing.T
-	expectedThreadID      uuid.UUID
-	expectedParticipantID uuid.UUID
-	expectedPassive       bool
-	called                bool
-	thread                store.Thread
-}
-
-func (f *fakeThreadStore) CreateThread(context.Context, []uuid.UUID) (store.Thread, error) {
-	panic("unexpected CreateThread call")
-}
-
-func (f *fakeThreadStore) ArchiveThread(context.Context, uuid.UUID) (store.Thread, error) {
-	panic("unexpected ArchiveThread call")
-}
-
-func (f *fakeThreadStore) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error) {
-	f.t.Helper()
-	f.called = true
-	if threadID != f.expectedThreadID {
-		f.t.Fatalf("expected thread ID %s, got %s", f.expectedThreadID, threadID)
-	}
-	if participantID != f.expectedParticipantID {
-		f.t.Fatalf("expected participant ID %s, got %s", f.expectedParticipantID, participantID)
-	}
-	if passive != f.expectedPassive {
-		f.t.Fatalf("expected passive %v, got %v", f.expectedPassive, passive)
-	}
-	return f.thread, nil
-}
-
-func (f *fakeThreadStore) SendMessage(context.Context, uuid.UUID, uuid.UUID, string, []uuid.UUID) (store.SendMessageResult, error) {
-	panic("unexpected SendMessage call")
-}
-
-func (f *fakeThreadStore) ListThreads(context.Context, uuid.UUID, int32, *store.ThreadCursor) (store.ThreadListResult, error) {
-	panic("unexpected ListThreads call")
-}
-
-func (f *fakeThreadStore) ListMessages(context.Context, uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
-	panic("unexpected ListMessages call")
-}
-
-func (f *fakeThreadStore) ListUnackedMessages(context.Context, uuid.UUID, *uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
-	panic("unexpected ListUnackedMessages call")
-}
-
-func (f *fakeThreadStore) AckMessages(context.Context, uuid.UUID, []uuid.UUID) (int32, error) {
-	panic("unexpected AckMessages call")
-}
-
-type fakeIdentityResolver struct {
+type stubThreadStore struct {
 	t                *testing.T
-	expectedOrgID    string
-	expectedNickname string
-	responseID       string
-	called           bool
+	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 }
 
-func (f *fakeIdentityResolver) ResolveNickname(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
-	f.t.Helper()
-	f.called = true
-	if req.GetOrganizationId() != f.expectedOrgID {
-		f.t.Fatalf("expected organization ID %s, got %s", f.expectedOrgID, req.GetOrganizationId())
+func (s *stubThreadStore) unexpectedCall(method string) {
+	s.t.Helper()
+	s.t.Fatalf("unexpected %s call", method)
+}
+
+func (s *stubThreadStore) CreateThread(context.Context, []uuid.UUID) (store.Thread, error) {
+	s.unexpectedCall("CreateThread")
+	return store.Thread{}, nil
+}
+
+func (s *stubThreadStore) ArchiveThread(context.Context, uuid.UUID) (store.Thread, error) {
+	s.unexpectedCall("ArchiveThread")
+	return store.Thread{}, nil
+}
+
+func (s *stubThreadStore) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error) {
+	s.t.Helper()
+	if s.addParticipantFn == nil {
+		s.t.Fatalf("unexpected AddParticipant call")
 	}
-	if req.GetNickname() != f.expectedNickname {
-		f.t.Fatalf("expected nickname %s, got %s", f.expectedNickname, req.GetNickname())
+	return s.addParticipantFn(ctx, threadID, participantID, passive)
+}
+
+func (s *stubThreadStore) SendMessage(context.Context, uuid.UUID, uuid.UUID, string, []uuid.UUID) (store.SendMessageResult, error) {
+	s.unexpectedCall("SendMessage")
+	return store.SendMessageResult{}, nil
+}
+
+func (s *stubThreadStore) ListThreads(context.Context, uuid.UUID, int32, *store.ThreadCursor) (store.ThreadListResult, error) {
+	s.unexpectedCall("ListThreads")
+	return store.ThreadListResult{}, nil
+}
+
+func (s *stubThreadStore) ListMessages(context.Context, uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
+	s.unexpectedCall("ListMessages")
+	return store.MessageListResult{}, nil
+}
+
+func (s *stubThreadStore) ListUnackedMessages(context.Context, uuid.UUID, *uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
+	s.unexpectedCall("ListUnackedMessages")
+	return store.MessageListResult{}, nil
+}
+
+func (s *stubThreadStore) AckMessages(context.Context, uuid.UUID, []uuid.UUID) (int32, error) {
+	s.unexpectedCall("AckMessages")
+	return 0, nil
+}
+
+type stubIdentityResolver struct {
+	t         *testing.T
+	resolveFn func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
+}
+
+func (s *stubIdentityResolver) ResolveNickname(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+	s.t.Helper()
+	if s.resolveFn == nil {
+		s.t.Fatalf("unexpected ResolveNickname call")
 	}
-	return &identityv1.ResolveNicknameResponse{IdentityId: f.responseID}, nil
+	return s.resolveFn(ctx, req, opts...)
 }
 
 func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
@@ -90,27 +86,45 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	organizationID := uuid.New()
 	participantID := uuid.New()
 	now := time.Now().UTC()
+	storeCalled := false
+	identityCalled := false
 
-	storeStub := &fakeThreadStore{
-		t:                     t,
-		expectedThreadID:      threadID,
-		expectedParticipantID: participantID,
-		expectedPassive:       true,
-		thread: store.Thread{
-			ID:        threadID,
-			Status:    store.ThreadStatusActive,
-			CreatedAt: now,
-			UpdatedAt: now,
-			Participants: []store.Participant{
-				{ID: participantID, JoinedAt: now, Passive: true},
-			},
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
+			}
+			if !passive {
+				t.Fatalf("expected passive true, got %v", passive)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: participantID, JoinedAt: now, Passive: true},
+				},
+			}, nil
 		},
 	}
-	identityStub := &fakeIdentityResolver{
-		t:                t,
-		expectedOrgID:    organizationID.String(),
-		expectedNickname: "agent-alpha",
-		responseID:       participantID.String(),
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-alpha" {
+				t.Fatalf("expected nickname agent-alpha, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
+		},
 	}
 
 	srv := New(storeStub, nil, identityStub)
@@ -126,10 +140,10 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddParticipant returned error: %v", err)
 	}
-	if !storeStub.called {
+	if !storeCalled {
 		t.Fatal("expected AddParticipant to be called")
 	}
-	if !identityStub.called {
+	if !identityCalled {
 		t.Fatal("expected ResolveNickname to be called")
 	}
 	if resp.GetThread() == nil || len(resp.GetThread().GetParticipants()) != 1 {
@@ -137,5 +151,96 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	}
 	if !resp.GetThread().GetParticipants()[0].GetPassive() {
 		t.Fatal("expected passive participant to be true")
+	}
+}
+
+func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
+	threadID := uuid.New()
+	participantID := uuid.New()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
+			}
+			if passive {
+				t.Fatalf("expected passive false, got %v", passive)
+			}
+			return store.Thread{ID: threadID}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil)
+	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantId{ParticipantId: participantID.String()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+}
+
+func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
+	threadID := uuid.New()
+	participantID := uuid.New()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
+			}
+			return store.Thread{ID: threadID}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil)
+	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+		ThreadId:      threadID.String(),
+		ParticipantId: participantID.String(),
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+}
+
+func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
+	threadID := uuid.New()
+
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t})
+	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "agent-alpha"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
 	}
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -155,24 +155,11 @@ func (s *Store) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize i
 	return MessageListResult{Messages: messages, NextCursor: nextCursor}, nil
 }
 
-func (s *Store) ListUnackedMessages(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *MessageCursor) (MessageListResult, error) {
+func (s *Store) ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *MessageCursor) (MessageListResult, error) {
 	limit := normalizePageSize(pageSize)
-	query := strings.Builder{}
-	query.WriteString(`SELECT m.id, m.thread_id, m.sender_id, m.body, m.file_ids, m.created_at
-        FROM message_recipients mr
-        JOIN messages m ON m.id = mr.message_id
-        WHERE mr.participant_id = $1 AND mr.acked_at IS NULL`)
-	args := []any{participantID}
-	paramIndex := 2
-	if cursor != nil {
-		query.WriteString(fmt.Sprintf(" AND (m.created_at, m.id) > ($%d, $%d)", paramIndex, paramIndex+1))
-		args = append(args, cursor.CreatedAt, cursor.MessageID)
-		paramIndex += 2
-	}
-	query.WriteString(fmt.Sprintf(" ORDER BY m.created_at ASC, m.id ASC LIMIT $%d", paramIndex))
-	args = append(args, int(limit)+1)
+	query, args := buildUnackedMessagesQuery(participantID, threadID, cursor, limit)
 
-	rows, err := s.pool.Query(ctx, query.String(), args...)
+	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return MessageListResult{}, err
 	}
@@ -211,6 +198,29 @@ func (s *Store) ListUnackedMessages(ctx context.Context, participantID uuid.UUID
 		nextCursor = &MessageCursor{CreatedAt: lastTime, MessageID: lastID}
 	}
 	return MessageListResult{Messages: messages, NextCursor: nextCursor}, nil
+}
+
+func buildUnackedMessagesQuery(participantID uuid.UUID, threadID *uuid.UUID, cursor *MessageCursor, limit int32) (string, []any) {
+	query := strings.Builder{}
+	query.WriteString(`SELECT m.id, m.thread_id, m.sender_id, m.body, m.file_ids, m.created_at
+        FROM message_recipients mr
+        JOIN messages m ON m.id = mr.message_id
+        WHERE mr.participant_id = $1 AND mr.acked_at IS NULL`)
+	args := []any{participantID}
+	paramIndex := 2
+	if threadID != nil {
+		query.WriteString(fmt.Sprintf(" AND m.thread_id = $%d", paramIndex))
+		args = append(args, *threadID)
+		paramIndex++
+	}
+	if cursor != nil {
+		query.WriteString(fmt.Sprintf(" AND (m.created_at, m.id) > ($%d, $%d)", paramIndex, paramIndex+1))
+		args = append(args, cursor.CreatedAt, cursor.MessageID)
+		paramIndex += 2
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY m.created_at ASC, m.id ASC LIMIT $%d", paramIndex))
+	args = append(args, int(limit)+1)
+	return query.String(), args
 }
 
 func (s *Store) AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error) {

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -43,6 +43,8 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 		if err != nil {
 			return err
 		}
+		// Passive participants still receive message notifications; workload
+		// triggers are handled downstream.
 		if len(recipients) > 0 {
 			rows := make([][]any, len(recipients))
 			for i, recipientID := range recipients {

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestBuildUnackedMessagesQueryIncludesThreadFilter(t *testing.T) {
+	participantID := uuid.New()
+	threadID := uuid.New()
+
+	query, args := buildUnackedMessagesQuery(participantID, &threadID, nil, 10)
+	if !strings.Contains(query, "m.thread_id = $2") {
+		t.Fatalf("expected thread filter in query, got %s", query)
+	}
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d", len(args))
+	}
+	if args[0] != participantID {
+		t.Fatalf("expected participant ID arg %s, got %v", participantID, args[0])
+	}
+	if args[1] != threadID {
+		t.Fatalf("expected thread ID arg %s, got %v", threadID, args[1])
+	}
+	if args[2] != 11 {
+		t.Fatalf("expected limit arg 11, got %v", args[2])
+	}
+}
+
+func TestBuildUnackedMessagesQueryWithoutThreadFilter(t *testing.T) {
+	participantID := uuid.New()
+
+	query, args := buildUnackedMessagesQuery(participantID, nil, nil, 10)
+	if strings.Contains(query, "AND m.thread_id") {
+		t.Fatalf("expected no thread filter, got %s", query)
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(args))
+	}
+	if args[0] != participantID {
+		t.Fatalf("expected participant ID arg %s, got %v", participantID, args[0])
+	}
+	if args[1] != 11 {
+		t.Fatalf("expected limit arg 11, got %v", args[1])
+	}
+}

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -44,5 +45,37 @@ func TestBuildUnackedMessagesQueryWithoutThreadFilter(t *testing.T) {
 	}
 	if args[1] != 11 {
 		t.Fatalf("expected limit arg 11, got %v", args[1])
+	}
+}
+
+func TestBuildUnackedMessagesQueryWithThreadAndCursor(t *testing.T) {
+	participantID := uuid.New()
+	threadID := uuid.New()
+	cursor := &MessageCursor{CreatedAt: time.Unix(0, 123).UTC(), MessageID: uuid.New()}
+
+	query, args := buildUnackedMessagesQuery(participantID, &threadID, cursor, 5)
+	if !strings.Contains(query, "m.thread_id = $2") {
+		t.Fatalf("expected thread filter in query, got %s", query)
+	}
+	if !strings.Contains(query, "(m.created_at, m.id) > ($3, $4)") {
+		t.Fatalf("expected cursor filter in query, got %s", query)
+	}
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d", len(args))
+	}
+	if args[0] != participantID {
+		t.Fatalf("expected participant ID arg %s, got %v", participantID, args[0])
+	}
+	if args[1] != threadID {
+		t.Fatalf("expected thread ID arg %s, got %v", threadID, args[1])
+	}
+	if args[2] != cursor.CreatedAt {
+		t.Fatalf("expected cursor time arg %v, got %v", cursor.CreatedAt, args[2])
+	}
+	if args[3] != cursor.MessageID {
+		t.Fatalf("expected cursor message ID arg %s, got %v", cursor.MessageID, args[3])
+	}
+	if args[4] != 6 {
+		t.Fatalf("expected limit arg 6, got %v", args[4])
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -84,7 +84,7 @@ func loadThread(ctx context.Context, q queryer, id uuid.UUID) (Thread, error) {
 }
 
 func loadParticipants(ctx context.Context, q queryer, threadID uuid.UUID) ([]Participant, error) {
-	rows, err := q.Query(ctx, `SELECT participant_id, joined_at FROM thread_participants WHERE thread_id = $1 ORDER BY joined_at ASC, participant_id ASC`, threadID)
+	rows, err := q.Query(ctx, `SELECT participant_id, joined_at, passive FROM thread_participants WHERE thread_id = $1 ORDER BY joined_at ASC, participant_id ASC`, threadID)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func loadParticipants(ctx context.Context, q queryer, threadID uuid.UUID) ([]Par
 	participants := []Participant{}
 	for rows.Next() {
 		var participant Participant
-		if err := rows.Scan(&participant.ID, &participant.JoinedAt); err != nil {
+		if err := rows.Scan(&participant.ID, &participant.JoinedAt, &participant.Passive); err != nil {
 			return nil, err
 		}
 		participants = append(participants, participant)

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -21,10 +21,10 @@ func (s *Store) CreateThread(ctx context.Context, participantIDs []uuid.UUID) (T
 		}
 		participants := make([]Participant, len(participantIDs))
 		for i, participantID := range participantIDs {
-			if _, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at) VALUES ($1, $2, $3)`, threadID, participantID, now); err != nil {
+			if _, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at, passive) VALUES ($1, $2, $3, $4)`, threadID, participantID, now, false); err != nil {
 				return err
 			}
-			participants[i] = Participant{ID: participantID, JoinedAt: now}
+			participants[i] = Participant{ID: participantID, JoinedAt: now, Passive: false}
 		}
 		thread = Thread{
 			ID:           threadID,
@@ -72,7 +72,7 @@ func (s *Store) ArchiveThread(ctx context.Context, threadID uuid.UUID) (Thread, 
 	return thread, nil
 }
 
-func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID) (Thread, error) {
+func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (Thread, error) {
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		status, createdAt, updatedAt, err := loadThreadRow(ctx, tx, threadID, true)
@@ -83,7 +83,7 @@ func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid
 			return ErrThreadArchived
 		}
 		now := time.Now().UTC()
-		cmd, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`, threadID, participantID, now)
+		cmd, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at, passive) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`, threadID, participantID, now, passive)
 		if err != nil {
 			return err
 		}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -41,6 +41,7 @@ type Thread struct {
 type Participant struct {
 	ID       uuid.UUID
 	JoinedAt time.Time
+	Passive  bool
 }
 
 type Message struct {

--- a/migrations/0002_add_passive_thread_participants.sql
+++ b/migrations/0002_add_passive_thread_participants.sql
@@ -1,0 +1,2 @@
+ALTER TABLE thread_participants
+    ADD COLUMN passive BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- add passive participant field to thread storage and proto conversion
- resolve participant nicknames via identity service
- allow thread-filtered unacked message queries
- add coverage for nickname adds and thread filters

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --include-imports
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go build ./...

Refs #132