### PR TITLE
feat: add threads metering records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
 
 COPY . .
 

--- a/charts/threads/values.yaml
+++ b/charts/threads/values.yaml
@@ -78,6 +78,8 @@ env:
     value: ""
   - name: IDENTITY_ADDRESS
     value: ""
+  - name: METERING_SERVICE_ADDRESS
+    value: ""
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/cmd/threads/main.go
+++ b/cmd/threads/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
+	meteringv1 "github.com/agynio/threads/.gen/go/agynio/api/metering/v1"
 	notificationsv1 "github.com/agynio/threads/.gen/go/agynio/api/notifications/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/agynio/threads/internal/config"
 	"github.com/agynio/threads/internal/db"
+	"github.com/agynio/threads/internal/metering"
 	"github.com/agynio/threads/internal/notifier"
 	"github.com/agynio/threads/internal/server"
 	"github.com/agynio/threads/internal/store"
@@ -65,6 +67,12 @@ func run() error {
 	}
 	defer identityConn.Close()
 
+	meteringConn, err := grpc.DialContext(ctx, cfg.MeteringServiceAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial metering: %w", err)
+	}
+	defer meteringConn.Close()
+
 	threadsServer := grpc.NewServer()
 	threadsv1.RegisterThreadsServiceServer(
 		threadsServer,
@@ -72,6 +80,7 @@ func run() error {
 			store.NewStore(pool),
 			notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
 			identityv1.NewIdentityServiceClient(identityConn),
+			metering.New(meteringv1.NewMeteringServiceClient(meteringConn)),
 		),
 	)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1
+                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
                   exec go run ./cmd/threads
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=threads-e2e" \
         -n ${THREADS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Config struct {
-	GRPCAddress          string
-	DatabaseURL          string
-	NotificationsAddress string
-	IdentityAddress      string
+	GRPCAddress            string
+	DatabaseURL            string
+	NotificationsAddress   string
+	IdentityAddress        string
+	MeteringServiceAddress string
 }
 
 func FromEnv() (Config, error) {
@@ -29,6 +30,10 @@ func FromEnv() (Config, error) {
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
 		return Config{}, fmt.Errorf("IDENTITY_ADDRESS must be set")
+	}
+	cfg.MeteringServiceAddress = os.Getenv("METERING_SERVICE_ADDRESS")
+	if cfg.MeteringServiceAddress == "" {
+		return Config{}, fmt.Errorf("METERING_SERVICE_ADDRESS must be set")
 	}
 	return cfg, nil
 }

--- a/internal/metering/metering.go
+++ b/internal/metering/metering.go
@@ -1,0 +1,78 @@
+package metering
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	meteringv1 "github.com/agynio/threads/.gen/go/agynio/api/metering/v1"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	producerName    = "threads"
+	countValue      = int64(1000000)
+	labelResource   = "resource"
+	labelResourceID = "resource_id"
+	labelKind       = "kind"
+	labelThreadID   = "thread_id"
+	resourceThread  = "thread"
+	resourceMessage = "message"
+	kindThread      = "thread"
+	kindMessage     = "message"
+)
+
+type Recorder struct {
+	client meteringv1.MeteringServiceClient
+}
+
+func New(client meteringv1.MeteringServiceClient) *Recorder {
+	return &Recorder{client: client}
+}
+
+func (r *Recorder) RecordThreadCreated(ctx context.Context, orgID, threadID uuid.UUID, createdAt time.Time) error {
+	record := &meteringv1.UsageRecord{
+		OrgId:          orgID.String(),
+		IdempotencyKey: threadID.String(),
+		Producer:       producerName,
+		Timestamp:      timestamppb.New(createdAt),
+		Labels: map[string]string{
+			labelResourceID: threadID.String(),
+			labelResource:   resourceThread,
+			labelKind:       kindThread,
+		},
+		Unit:  meteringv1.Unit_UNIT_COUNT,
+		Value: countValue,
+	}
+	return r.record(ctx, record)
+}
+
+func (r *Recorder) RecordMessageSent(ctx context.Context, orgID, threadID, messageID uuid.UUID, createdAt time.Time) error {
+	record := &meteringv1.UsageRecord{
+		OrgId:          orgID.String(),
+		IdempotencyKey: messageID.String(),
+		Producer:       producerName,
+		Timestamp:      timestamppb.New(createdAt),
+		Labels: map[string]string{
+			labelResourceID: messageID.String(),
+			labelResource:   resourceMessage,
+			labelKind:       kindMessage,
+			labelThreadID:   threadID.String(),
+		},
+		Unit:  meteringv1.Unit_UNIT_COUNT,
+		Value: countValue,
+	}
+	return r.record(ctx, record)
+}
+
+func (r *Recorder) record(ctx context.Context, record *meteringv1.UsageRecord) error {
+	if r == nil {
+		return nil
+	}
+	_, err := r.client.Record(ctx, &meteringv1.RecordRequest{Records: []*meteringv1.UsageRecord{record}})
+	if err != nil {
+		return fmt.Errorf("record usage: %w", err)
+	}
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
+	"time"
 
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/agynio/threads/internal/store"
@@ -20,7 +24,13 @@ type Server struct {
 	store    threadStore
 	notifier notifierPublisher
 	identity identityResolver
+	metering meteringRecorder
 }
+
+const (
+	organizationIDMetadataKey = "x-organization-id"
+	meteringTimeout           = 5 * time.Second
+)
 
 type threadStore interface {
 	CreateThread(ctx context.Context, participantIDs []uuid.UUID) (store.Thread, error)
@@ -41,8 +51,13 @@ type notifierPublisher interface {
 	PublishMessageCreated(ctx context.Context, threadID, messageID uuid.UUID, recipients []uuid.UUID) error
 }
 
-func New(store threadStore, notifier notifierPublisher, identity identityResolver) *Server {
-	return &Server{store: store, notifier: notifier, identity: identity}
+type meteringRecorder interface {
+	RecordThreadCreated(ctx context.Context, orgID, threadID uuid.UUID, createdAt time.Time) error
+	RecordMessageSent(ctx context.Context, orgID, threadID, messageID uuid.UUID, createdAt time.Time) error
+}
+
+func New(store threadStore, notifier notifierPublisher, identity identityResolver, metering meteringRecorder) *Server {
+	return &Server{store: store, notifier: notifier, identity: identity, metering: metering}
 }
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
@@ -68,6 +83,7 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	s.recordThreadCreated(ctx, thread)
 	return &threadsv1.CreateThreadResponse{Thread: toProtoThread(thread)}, nil
 }
 
@@ -124,6 +140,7 @@ func (s *Server) SendMessage(ctx context.Context, req *threadsv1.SendMessageRequ
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	s.recordMessageSent(ctx, result.Message)
 	if err := s.notifier.PublishMessageCreated(ctx, threadID, result.Message.ID, result.Recipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "notify recipients: %v", err)
 	}
@@ -267,6 +284,44 @@ func (s *Server) AckMessages(ctx context.Context, req *threadsv1.AckMessagesRequ
 	return &threadsv1.AckMessagesResponse{AckedCount: count}, nil
 }
 
+func (s *Server) recordThreadCreated(ctx context.Context, thread store.Thread) {
+	threadID := thread.ID
+	createdAt := thread.CreatedAt
+	s.recordUsageAsync(ctx, "thread_created", func(recordCtx context.Context, orgID uuid.UUID) error {
+		return s.metering.RecordThreadCreated(recordCtx, orgID, threadID, createdAt)
+	})
+}
+
+func (s *Server) recordMessageSent(ctx context.Context, message store.Message) {
+	messageID := message.ID
+	threadID := message.ThreadID
+	createdAt := message.CreatedAt
+	s.recordUsageAsync(ctx, "message_sent", func(recordCtx context.Context, orgID uuid.UUID) error {
+		return s.metering.RecordMessageSent(recordCtx, orgID, threadID, messageID, createdAt)
+	})
+}
+
+func (s *Server) recordUsageAsync(ctx context.Context, label string, record func(context.Context, uuid.UUID) error) {
+	if s.metering == nil {
+		return
+	}
+	orgID, ok, err := organizationIDFromContext(ctx)
+	if err != nil {
+		log.Printf("metering: %s: %v", label, err)
+		return
+	}
+	if !ok {
+		return
+	}
+	go func() {
+		recordCtx, cancel := context.WithTimeout(context.Background(), meteringTimeout)
+		defer cancel()
+		if err := record(recordCtx, orgID); err != nil {
+			log.Printf("metering: %s: %v", label, err)
+		}
+	}()
+}
+
 func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
 	if req.GetParticipant() == nil {
 		participantID, err := parseUUID(req.GetParticipantId())
@@ -309,6 +364,26 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 	default:
 		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
 	}
+}
+
+func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, false, nil
+	}
+	values := md.Get(organizationIDMetadataKey)
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		orgID, err := parseUUID(trimmed)
+		if err != nil {
+			return uuid.UUID{}, false, fmt.Errorf("organization_id: %w", err)
+		}
+		return orgID, true, nil
+	}
+	return uuid.UUID{}, false, nil
 }
 
 func parseUUID(value string) (uuid.UUID, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -127,7 +127,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub)
+	srv := New(storeStub, nil, identityStub, nil)
 	orgIDValue := organizationID.String()
 	resp, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId:       threadID.String(),
@@ -176,7 +176,7 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil)
+	srv := New(storeStub, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{
@@ -210,7 +210,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil)
+	srv := New(storeStub, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId:      threadID.String(),
 		ParticipantId: participantID.String(),
@@ -226,7 +226,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 	threadID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t})
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{


### PR DESCRIPTION
## Summary
- add metering recorder and fire-and-forget usage records for thread/message creation
- wire metering service config/env and client setup
- update buf generation paths and Helm values for metering env

## Testing
- GOTOOLCHAIN=local CGO_ENABLED=0 go test ./...
- GOTOOLCHAIN=local CGO_ENABLED=0 go vet ./...

Refs agynio/metering#1