### PR TITLE
fix: separate service-base templates

### DIFF
--- a/charts/threads/templates/service-base.yaml
+++ b/charts/threads/templates/service-base.yaml
@@ -1,8 +1,15 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- add document separators between service-base includes to avoid concatenated YAML
- switch includes to non-trimmed form for consistent rendering

## Testing
- helm dependency build charts/threads
- helm lint charts/threads
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

Refs agynio/metering#1