### PR TITLE
fix(config): default service addresses

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,15 +25,15 @@ func FromEnv() (Config, error) {
 	}
 	cfg.NotificationsAddress = os.Getenv("NOTIFICATIONS_ADDRESS")
 	if cfg.NotificationsAddress == "" {
-		return Config{}, fmt.Errorf("NOTIFICATIONS_ADDRESS must be set")
+		cfg.NotificationsAddress = "notifications:50051"
 	}
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
-		return Config{}, fmt.Errorf("IDENTITY_ADDRESS must be set")
+		cfg.IdentityAddress = "identity:50051"
 	}
 	cfg.MeteringServiceAddress = os.Getenv("METERING_SERVICE_ADDRESS")
 	if cfg.MeteringServiceAddress == "" {
-		return Config{}, fmt.Errorf("METERING_SERVICE_ADDRESS must be set")
+		cfg.MeteringServiceAddress = "metering:50051"
 	}
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import "testing"
+
+func TestFromEnvDefaults(t *testing.T) {
+	t.Setenv("GRPC_ADDRESS", "")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/threads")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("IDENTITY_ADDRESS", "")
+	t.Setenv("METERING_SERVICE_ADDRESS", "")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error: %v", err)
+	}
+	if cfg.GRPCAddress != ":50051" {
+		t.Fatalf("expected default GRPC address :50051, got %q", cfg.GRPCAddress)
+	}
+	if cfg.DatabaseURL != "postgres://user:pass@localhost:5432/threads" {
+		t.Fatalf("expected database url to be set, got %q", cfg.DatabaseURL)
+	}
+	if cfg.NotificationsAddress != "notifications:50051" {
+		t.Fatalf("expected notifications address notifications:50051, got %q", cfg.NotificationsAddress)
+	}
+	if cfg.IdentityAddress != "identity:50051" {
+		t.Fatalf("expected identity address identity:50051, got %q", cfg.IdentityAddress)
+	}
+	if cfg.MeteringServiceAddress != "metering:50051" {
+		t.Fatalf("expected metering address metering:50051, got %q", cfg.MeteringServiceAddress)
+	}
+}
+
+func TestFromEnvOverrides(t *testing.T) {
+	t.Setenv("GRPC_ADDRESS", "0.0.0.0:9999")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@db:5432/threads")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "notifications.internal:6000")
+	t.Setenv("IDENTITY_ADDRESS", "identity.internal:6001")
+	t.Setenv("METERING_SERVICE_ADDRESS", "metering.internal:6002")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error: %v", err)
+	}
+	if cfg.GRPCAddress != "0.0.0.0:9999" {
+		t.Fatalf("expected grpc address 0.0.0.0:9999, got %q", cfg.GRPCAddress)
+	}
+	if cfg.NotificationsAddress != "notifications.internal:6000" {
+		t.Fatalf("expected notifications address override, got %q", cfg.NotificationsAddress)
+	}
+	if cfg.IdentityAddress != "identity.internal:6001" {
+		t.Fatalf("expected identity address override, got %q", cfg.IdentityAddress)
+	}
+	if cfg.MeteringServiceAddress != "metering.internal:6002" {
+		t.Fatalf("expected metering address override, got %q", cfg.MeteringServiceAddress)
+	}
+}
+
+func TestFromEnvRequiresDatabaseURL(t *testing.T) {
+	t.Setenv("GRPC_ADDRESS", "")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("IDENTITY_ADDRESS", "")
+	t.Setenv("METERING_SERVICE_ADDRESS", "")
+
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("expected error when DATABASE_URL is missing")
+	}
+}


### PR DESCRIPTION
## Summary
- default notifications, identity, and metering service addresses when env vars are unset
- keep DATABASE_URL required and add config tests for defaults/overrides

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/authorization/v1 --include-imports
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...

Ref: #1