### PR TITLE
fix(threads): resolve participant identifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml buf.lock ./
+COPY buf.gen.yaml buf.yaml ./
 RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml buf.yaml buf.lock ./
 RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
 
 COPY . .
 

--- a/cmd/threads/main.go
+++ b/cmd/threads/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	meteringv1 "github.com/agynio/threads/.gen/go/agynio/api/metering/v1"
 	notificationsv1 "github.com/agynio/threads/.gen/go/agynio/api/notifications/v1"
@@ -67,6 +68,12 @@ func run() error {
 	}
 	defer identityConn.Close()
 
+	agentsConn, err := grpc.DialContext(ctx, cfg.AgentsServiceAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial agents: %w", err)
+	}
+	defer agentsConn.Close()
+
 	meteringConn, err := grpc.DialContext(ctx, cfg.MeteringServiceAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial metering: %w", err)
@@ -80,6 +87,7 @@ func run() error {
 			store.NewStore(pool),
 			notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
 			identityv1.NewIdentityServiceClient(identityConn),
+			agentsv1.NewAgentsServiceClient(agentsConn),
 			metering.New(meteringv1.NewMeteringServiceClient(meteringConn)),
 		),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	DatabaseURL            string
 	NotificationsAddress   string
 	IdentityAddress        string
+	AgentsServiceAddress   string
 	MeteringServiceAddress string
 }
 
@@ -30,6 +31,10 @@ func FromEnv() (Config, error) {
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
 		cfg.IdentityAddress = "identity:50051"
+	}
+	cfg.AgentsServiceAddress = os.Getenv("AGENTS_SERVICE_ADDRESS")
+	if cfg.AgentsServiceAddress == "" {
+		cfg.AgentsServiceAddress = "agents:50051"
 	}
 	cfg.MeteringServiceAddress = os.Getenv("METERING_SERVICE_ADDRESS")
 	if cfg.MeteringServiceAddress == "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -323,13 +323,6 @@ func (s *Server) recordUsageAsync(ctx context.Context, label string, record func
 }
 
 func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
-	if req.GetParticipantIdentifier() != "" {
-		identifier := strings.TrimSpace(req.GetParticipantIdentifier())
-		if identifier == "" {
-			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant_identifier must be provided")
-		}
-		return s.resolveParticipantIdentifier(ctx, req, identifier, "participant_identifier", strings.HasPrefix(identifier, "@"))
-	}
 	if req.GetParticipant() != nil {
 		identifier := req.GetParticipant().GetIdentifier()
 		switch value := identifier.(type) {
@@ -340,7 +333,7 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 			}
 			return participantID, nil
 		case *threadsv1.ParticipantIdentifier_ParticipantNickname:
-			return s.resolveParticipantIdentifier(ctx, req, value.ParticipantNickname, "participant.participant_nickname", true)
+			return s.resolveParticipantNickname(ctx, req, value.ParticipantNickname)
 		default:
 			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
 		}
@@ -352,31 +345,24 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 		}
 		return participantID, nil
 	}
-	return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant_identifier must be provided")
+	return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
 }
 
-func (s *Server) resolveParticipantIdentifier(ctx context.Context, req *threadsv1.AddParticipantRequest, identifier, fieldName string, isNickname bool) (uuid.UUID, error) {
-	trimmed := strings.TrimSpace(identifier)
+func (s *Server) resolveParticipantNickname(ctx context.Context, req *threadsv1.AddParticipantRequest, nickname string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(nickname)
 	if trimmed == "" {
-		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s must be provided", fieldName)
-	}
-	if !isNickname {
-		participantID, err := parseUUID(trimmed)
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s: %v", fieldName, err)
-		}
-		return participantID, nil
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
 	}
 	cleaned := strings.TrimPrefix(trimmed, "@")
 	if cleaned == "" {
-		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s: nickname must be provided", fieldName)
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
 	}
 	organizationID, ok, err := organizationIDForNickname(ctx, req)
 	if err != nil {
 		return uuid.UUID{}, err
 	}
 	if !ok {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant identifier")
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
 	}
 	response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
 		OrganizationId: organizationID.String(),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -323,47 +323,88 @@ func (s *Server) recordUsageAsync(ctx context.Context, label string, record func
 }
 
 func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
-	if req.GetParticipant() == nil {
-		participantID, err := parseUUID(req.GetParticipantId())
+	if req.GetParticipantIdentifier() != "" {
+		identifier := strings.TrimSpace(req.GetParticipantIdentifier())
+		if identifier == "" {
+			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant_identifier must be provided")
+		}
+		return s.resolveParticipantIdentifier(ctx, req, identifier, "participant_identifier", strings.HasPrefix(identifier, "@"))
+	}
+	if req.GetParticipant() != nil {
+		identifier := req.GetParticipant().GetIdentifier()
+		switch value := identifier.(type) {
+		case *threadsv1.ParticipantIdentifier_ParticipantId:
+			participantID, err := parseUUID(strings.TrimSpace(value.ParticipantId))
+			if err != nil {
+				return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "participant.participant_id: %v", err)
+			}
+			return participantID, nil
+		case *threadsv1.ParticipantIdentifier_ParticipantNickname:
+			return s.resolveParticipantIdentifier(ctx, req, value.ParticipantNickname, "participant.participant_nickname", true)
+		default:
+			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
+		}
+	}
+	if req.GetParticipantId() != "" {
+		participantID, err := parseUUID(strings.TrimSpace(req.GetParticipantId()))
 		if err != nil {
 			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "participant_id: %v", err)
 		}
 		return participantID, nil
 	}
-	identifier := req.GetParticipant().GetIdentifier()
-	switch value := identifier.(type) {
-	case *threadsv1.ParticipantIdentifier_ParticipantId:
-		participantID, err := parseUUID(value.ParticipantId)
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "participant.participant_id: %v", err)
-		}
-		return participantID, nil
-	case *threadsv1.ParticipantIdentifier_ParticipantNickname:
-		if req.OrganizationId == nil {
-			return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
-		}
-		if value.ParticipantNickname == "" {
-			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
-		}
-		organizationID, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
-			OrganizationId: organizationID.String(),
-			Nickname:       value.ParticipantNickname,
-		})
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname: %v", err)
-		}
-		participantID, err := parseUUID(response.GetIdentityId())
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname identity_id: %v", err)
-		}
-		return participantID, nil
-	default:
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
+	return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant_identifier must be provided")
+}
+
+func (s *Server) resolveParticipantIdentifier(ctx context.Context, req *threadsv1.AddParticipantRequest, identifier, fieldName string, isNickname bool) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s must be provided", fieldName)
 	}
+	if !isNickname {
+		participantID, err := parseUUID(trimmed)
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s: %v", fieldName, err)
+		}
+		return participantID, nil
+	}
+	cleaned := strings.TrimPrefix(trimmed, "@")
+	if cleaned == "" {
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s: nickname must be provided", fieldName)
+	}
+	organizationID, ok, err := organizationIDForNickname(ctx, req)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	if !ok {
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant identifier")
+	}
+	response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
+		OrganizationId: organizationID.String(),
+		Nickname:       cleaned,
+	})
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname: %v", err)
+	}
+	participantID, err := parseUUID(response.GetIdentityId())
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "resolve nickname identity_id: %v", err)
+	}
+	return participantID, nil
+}
+
+func organizationIDForNickname(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, bool, error) {
+	if req.OrganizationId != nil {
+		organizationID, err := parseUUID(strings.TrimSpace(req.GetOrganizationId()))
+		if err != nil {
+			return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		return organizationID, true, nil
+	}
+	organizationID, ok, err := organizationIDFromContext(ctx)
+	if err != nil {
+		return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	return organizationID, ok, nil
 }
 
 func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -24,11 +25,15 @@ type Server struct {
 	store    threadStore
 	notifier notifierPublisher
 	identity identityResolver
+	agents   agentsService
 	metering meteringRecorder
 }
 
 const (
 	organizationIDMetadataKey = "x-organization-id"
+	identityIDMetadataKey     = "x-identity-id"
+	identityTypeMetadataKey   = "x-identity-type"
+	agentIdentityType         = "agent"
 	meteringTimeout           = 5 * time.Second
 )
 
@@ -47,6 +52,10 @@ type identityResolver interface {
 	ResolveNickname(ctx context.Context, in *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
 }
 
+type agentsService interface {
+	GetAgent(ctx context.Context, in *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+}
+
 type notifierPublisher interface {
 	PublishMessageCreated(ctx context.Context, threadID, messageID uuid.UUID, recipients []uuid.UUID) error
 }
@@ -56,8 +65,8 @@ type meteringRecorder interface {
 	RecordMessageSent(ctx context.Context, orgID, threadID, messageID uuid.UUID, createdAt time.Time) error
 }
 
-func New(store threadStore, notifier notifierPublisher, identity identityResolver, metering meteringRecorder) *Server {
-	return &Server{store: store, notifier: notifier, identity: identity, metering: metering}
+func New(store threadStore, notifier notifierPublisher, identity identityResolver, agents agentsService, metering meteringRecorder) *Server {
+	return &Server{store: store, notifier: notifier, identity: identity, agents: agents, metering: metering}
 }
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
@@ -357,12 +366,9 @@ func (s *Server) resolveParticipantNickname(ctx context.Context, req *threadsv1.
 	if cleaned == "" {
 		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
 	}
-	organizationID, ok, err := organizationIDForNickname(ctx, req)
+	organizationID, err := s.organizationIDForNickname(ctx, req)
 	if err != nil {
 		return uuid.UUID{}, err
-	}
-	if !ok {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
 	}
 	response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
 		OrganizationId: organizationID.String(),
@@ -378,19 +384,22 @@ func (s *Server) resolveParticipantNickname(ctx context.Context, req *threadsv1.
 	return participantID, nil
 }
 
-func organizationIDForNickname(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, bool, error) {
+func (s *Server) organizationIDForNickname(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
 	if req.OrganizationId != nil {
 		organizationID, err := parseUUID(strings.TrimSpace(req.GetOrganizationId()))
 		if err != nil {
-			return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
-		return organizationID, true, nil
+		return organizationID, nil
 	}
 	organizationID, ok, err := organizationIDFromContext(ctx)
 	if err != nil {
-		return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "%v", err)
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	return organizationID, ok, nil
+	if ok {
+		return organizationID, nil
+	}
+	return s.organizationIDFromIdentity(ctx)
 }
 
 func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
@@ -398,19 +407,62 @@ func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
 	if !ok {
 		return uuid.UUID{}, false, nil
 	}
-	values := md.Get(organizationIDMetadataKey)
+	value := metadataValue(md, organizationIDMetadataKey)
+	if value == "" {
+		return uuid.UUID{}, false, nil
+	}
+	orgID, err := parseUUID(value)
+	if err != nil {
+		return uuid.UUID{}, false, fmt.Errorf("organization_id: %w", err)
+	}
+	return orgID, true, nil
+}
+
+func (s *Server) organizationIDFromIdentity(ctx context.Context) (uuid.UUID, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+	}
+	identityID := metadataValue(md, identityIDMetadataKey)
+	identityType := metadataValue(md, identityTypeMetadataKey)
+	if identityID == "" || identityType == "" {
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+	}
+	if !strings.EqualFold(identityType, agentIdentityType) {
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+	}
+	if s.agents == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
+	}
+	response, err := s.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: identityID})
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent: %v", err)
+	}
+	agent := response.GetAgent()
+	if agent == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "get agent: agent missing")
+	}
+	orgIDValue := strings.TrimSpace(agent.GetOrganizationId())
+	if orgIDValue == "" {
+		return uuid.UUID{}, status.Error(codes.Internal, "get agent: organization_id missing")
+	}
+	orgID, err := parseUUID(orgIDValue)
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent organization_id: %v", err)
+	}
+	return orgID, nil
+}
+
+func metadataValue(md metadata.MD, key string) string {
+	values := md.Get(key)
 	for _, value := range values {
 		trimmed := strings.TrimSpace(value)
 		if trimmed == "" {
 			continue
 		}
-		orgID, err := parseUUID(trimmed)
-		if err != nil {
-			return uuid.UUID{}, false, fmt.Errorf("organization_id: %w", err)
-		}
-		return orgID, true, nil
+		return trimmed
 	}
-	return uuid.UUID{}, false, nil
+	return ""
 }
 
 func parseUUID(value string) (uuid.UUID, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/agynio/threads/internal/store"
@@ -130,12 +131,10 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	srv := New(storeStub, nil, identityStub, nil)
 	orgIDValue := organizationID.String()
 	resp, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
-		ThreadId:       threadID.String(),
-		OrganizationId: &orgIDValue,
-		Passive:        true,
-		Participant: &threadsv1.ParticipantIdentifier{
-			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "agent-alpha"},
-		},
+		ThreadId:              threadID.String(),
+		OrganizationId:        &orgIDValue,
+		Passive:               true,
+		ParticipantIdentifier: "@agent-alpha",
 	})
 	if err != nil {
 		t.Fatalf("AddParticipant returned error: %v", err)
@@ -154,7 +153,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	}
 }
 
-func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
+func TestAddParticipantWithParticipantIdentifierUUID(t *testing.T) {
 	threadID := uuid.New()
 	participantID := uuid.New()
 	storeCalled := false
@@ -171,6 +170,38 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 			}
 			if passive {
 				t.Fatalf("expected passive false, got %v", passive)
+			}
+			return store.Thread{ID: threadID}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil)
+	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+		ThreadId:              threadID.String(),
+		ParticipantIdentifier: participantID.String(),
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+}
+
+func TestAddParticipantWithDeprecatedParticipantOneof(t *testing.T) {
+	threadID := uuid.New()
+	participantID := uuid.New()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
 			}
 			return store.Thread{ID: threadID}, nil
 		},
@@ -228,10 +259,8 @@ func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 
 	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
-		ThreadId: threadID.String(),
-		Participant: &threadsv1.ParticipantIdentifier{
-			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "agent-alpha"},
-		},
+		ThreadId:              threadID.String(),
+		ParticipantIdentifier: "@agent-alpha",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -242,5 +271,56 @@ func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 	}
 	if st.Code() != codes.InvalidArgument {
 		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+}
+
+func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	participantID := uuid.New()
+	storeCalled := false
+	identityCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
+			}
+			return store.Thread{ID: threadID}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-beta" {
+				t.Fatalf("expected nickname agent-beta, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, identityStub, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
+	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
+		ThreadId:              threadID.String(),
+		ParticipantIdentifier: "@agent-beta",
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected ResolveNickname to be called")
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -131,10 +131,12 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	srv := New(storeStub, nil, identityStub, nil)
 	orgIDValue := organizationID.String()
 	resp, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
-		ThreadId:              threadID.String(),
-		OrganizationId:        &orgIDValue,
-		Passive:               true,
-		ParticipantIdentifier: "@agent-alpha",
+		ThreadId:       threadID.String(),
+		OrganizationId: &orgIDValue,
+		Passive:        true,
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-alpha"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("AddParticipant returned error: %v", err)
@@ -153,7 +155,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	}
 }
 
-func TestAddParticipantWithParticipantIdentifierUUID(t *testing.T) {
+func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 	threadID := uuid.New()
 	participantID := uuid.New()
 	storeCalled := false
@@ -170,38 +172,6 @@ func TestAddParticipantWithParticipantIdentifierUUID(t *testing.T) {
 			}
 			if passive {
 				t.Fatalf("expected passive false, got %v", passive)
-			}
-			return store.Thread{ID: threadID}, nil
-		},
-	}
-
-	srv := New(storeStub, nil, nil, nil)
-	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
-		ThreadId:              threadID.String(),
-		ParticipantIdentifier: participantID.String(),
-	})
-	if err != nil {
-		t.Fatalf("AddParticipant returned error: %v", err)
-	}
-	if !storeCalled {
-		t.Fatal("expected AddParticipant to be called")
-	}
-}
-
-func TestAddParticipantWithDeprecatedParticipantOneof(t *testing.T) {
-	threadID := uuid.New()
-	participantID := uuid.New()
-	storeCalled := false
-
-	storeStub := &stubThreadStore{
-		t: t,
-		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
-			storeCalled = true
-			if threadArg != threadID {
-				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
-			}
-			if participantArg != participantID {
-				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
 			}
 			return store.Thread{ID: threadID}, nil
 		},
@@ -259,8 +229,10 @@ func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 
 	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
-		ThreadId:              threadID.String(),
-		ParticipantIdentifier: "@agent-alpha",
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-alpha"},
+		},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -271,6 +243,9 @@ func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 	}
 	if st.Code() != codes.InvalidArgument {
 		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "organization_id must be provided for participant_nickname" {
+		t.Fatalf("expected organization_id error, got %s", st.Message())
 	}
 }
 
@@ -311,8 +286,10 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 	srv := New(storeStub, nil, identityStub, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
 	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
-		ThreadId:              threadID.String(),
-		ParticipantIdentifier: "@agent-beta",
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-beta"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("AddParticipant returned error: %v", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -82,6 +83,19 @@ func (s *stubIdentityResolver) ResolveNickname(ctx context.Context, req *identit
 	return s.resolveFn(ctx, req, opts...)
 }
 
+type stubAgentsService struct {
+	t          *testing.T
+	getAgentFn func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+}
+
+func (s *stubAgentsService) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+	s.t.Helper()
+	if s.getAgentFn == nil {
+		s.t.Fatalf("unexpected GetAgent call")
+	}
+	return s.getAgentFn(ctx, req, opts...)
+}
+
 func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 	threadID := uuid.New()
 	organizationID := uuid.New()
@@ -128,9 +142,10 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil)
+	srv := New(storeStub, nil, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
-	resp, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", uuid.New().String()))
+	resp, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
 		ThreadId:       threadID.String(),
 		OrganizationId: &orgIDValue,
 		Passive:        true,
@@ -177,7 +192,7 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{
@@ -211,7 +226,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId:      threadID.String(),
 		ParticipantId: participantID.String(),
@@ -227,7 +242,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 	threadID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil)
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{
@@ -283,7 +298,7 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil)
+	srv := New(storeStub, nil, identityStub, nil, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
 	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
@@ -299,5 +314,181 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 	}
 	if !identityCalled {
 		t.Fatal("expected ResolveNickname to be called")
+	}
+}
+
+func TestAddParticipantNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	participantID := uuid.New()
+	storeCalled := false
+	identityCalled := false
+	agentCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
+			}
+			if participantArg != participantID {
+				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
+			}
+			return store.Thread{ID: threadID}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-gamma" {
+				t.Fatalf("expected nickname agent-gamma, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		getAgentFn: func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			agentCalled = true
+			if req.GetId() != agentID.String() {
+				t.Fatalf("expected agent ID %s, got %s", agentID, req.GetId())
+			}
+			return &agentsv1.GetAgentResponse{
+				Agent: &agentsv1.Agent{OrganizationId: organizationID.String()},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, identityStub, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-gamma"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddParticipant returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+	if !agentCalled {
+		t.Fatal("expected GetAgent to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected ResolveNickname to be called")
+	}
+}
+
+func TestAddParticipantNicknameRejectsNonAgentIdentityTypes(t *testing.T) {
+	threadID := uuid.New()
+	identityID := uuid.New()
+	identityTypes := []string{"user", "runner", "app"}
+
+	for _, identityType := range identityTypes {
+		t.Run(identityType, func(t *testing.T) {
+			srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
+			ctx := metadata.NewIncomingContext(
+				context.Background(),
+				metadata.Pairs("x-identity-id", identityID.String(), "x-identity-type", identityType),
+			)
+			_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
+				ThreadId: threadID.String(),
+				Participant: &threadsv1.ParticipantIdentifier{
+					Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent"},
+				},
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+			}
+			if st.Message() != "organization_id must be provided for participant_nickname" {
+				t.Fatalf("expected organization_id error, got %s", st.Message())
+			}
+		})
+	}
+}
+
+func TestAddParticipantNicknameAgentLookupError(t *testing.T) {
+	threadID := uuid.New()
+	agentID := uuid.New()
+
+	agentsStub := &stubAgentsService{
+		t: t,
+		getAgentFn: func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return nil, status.Error(codes.Internal, "agent down")
+		},
+	}
+
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got %s: %s", st.Code(), st.Message())
+	}
+}
+
+func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
+	threadID := uuid.New()
+	agentID := uuid.New()
+
+	agentsStub := &stubAgentsService{
+		t: t,
+		getAgentFn: func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{}}, nil
+		},
+	}
+
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
+		ThreadId: threadID.String(),
+		Participant: &threadsv1.ParticipantIdentifier{
+			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got %s: %s", st.Code(), st.Message())
 	}
 }


### PR DESCRIPTION
## Summary
- resolve participant identifiers via org metadata or request org id
- strip @ prefixes before nickname resolution and add coverage
- copy buf.lock before buf generate in Dockerfile

## Testing
- buf generate ../api --path ../api/proto/agynio/api/threads/v1 --path ../api/proto/agynio/api/notifications/v1 --path ../api/proto/agynio/api/identity/v1 --path ../api/proto/agynio/api/metering/v1
- go vet ./...
- go test ./...
- go build ./...

Refs #14