### PR TITLE
fix(threads): set agent initiator passive

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,7 +38,7 @@ const (
 )
 
 type threadStore interface {
-	CreateThread(ctx context.Context, participantIDs []uuid.UUID) (store.Thread, error)
+	CreateThread(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error)
 	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
@@ -88,7 +88,20 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 		participantIDs[i] = id
 	}
 
-	thread, err := s.store.CreateThread(ctx, participantIDs)
+	agentInitiatorID, isAgentInitiator, err := agentInitiatorID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	participants := make([]store.ParticipantInput, len(participantIDs))
+	for i, participantID := range participantIDs {
+		passive := false
+		if isAgentInitiator && participantID == agentInitiatorID {
+			passive = true
+		}
+		participants[i] = store.ParticipantInput{ID: participantID, Passive: passive}
+	}
+
+	thread, err := s.store.CreateThread(ctx, participants)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -451,6 +464,29 @@ func (s *Server) organizationIDFromIdentity(ctx context.Context) (uuid.UUID, err
 		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent organization_id: %v", err)
 	}
 	return orgID, nil
+}
+
+func agentInitiatorID(ctx context.Context) (uuid.UUID, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, false, nil
+	}
+	identityType := metadataValue(md, identityTypeMetadataKey)
+	if identityType == "" {
+		return uuid.UUID{}, false, nil
+	}
+	if !strings.EqualFold(identityType, agentIdentityType) {
+		return uuid.UUID{}, false, nil
+	}
+	identityID := metadataValue(md, identityIDMetadataKey)
+	if identityID == "" {
+		return uuid.UUID{}, false, nil
+	}
+	initiatorID, err := parseUUID(identityID)
+	if err != nil {
+		return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	return initiatorID, true, nil
 }
 
 func metadataValue(md metadata.MD, key string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,17 +88,25 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 		participantIDs[i] = id
 	}
 
-	agentInitiatorID, isAgentInitiator, err := agentInitiatorID(ctx)
+	initiator, hasInitiator, err := initiatorInfoFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	participants := make([]store.ParticipantInput, len(participantIDs))
-	for i, participantID := range participantIDs {
-		passive := false
-		if isAgentInitiator && participantID == agentInitiatorID {
-			passive = true
+	if hasInitiator {
+		if _, ok := seen[initiator.ID]; ok {
+			return nil, status.Error(codes.InvalidArgument, "participant_ids must not include initiator")
 		}
-		participants[i] = store.ParticipantInput{ID: participantID, Passive: passive}
+	}
+	capacity := len(participantIDs)
+	if hasInitiator {
+		capacity++
+	}
+	participants := make([]store.ParticipantInput, 0, capacity)
+	if hasInitiator {
+		participants = append(participants, store.ParticipantInput{ID: initiator.ID, Passive: initiator.Passive})
+	}
+	for _, participantID := range participantIDs {
+		participants = append(participants, store.ParticipantInput{ID: participantID, Passive: false})
 	}
 
 	thread, err := s.store.CreateThread(ctx, participants)
@@ -466,27 +474,27 @@ func (s *Server) organizationIDFromIdentity(ctx context.Context) (uuid.UUID, err
 	return orgID, nil
 }
 
-func agentInitiatorID(ctx context.Context) (uuid.UUID, bool, error) {
+type initiatorInfo struct {
+	ID      uuid.UUID
+	Passive bool
+}
+
+func initiatorInfoFromContext(ctx context.Context) (initiatorInfo, bool, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return uuid.UUID{}, false, nil
-	}
-	identityType := metadataValue(md, identityTypeMetadataKey)
-	if identityType == "" {
-		return uuid.UUID{}, false, nil
-	}
-	if !strings.EqualFold(identityType, agentIdentityType) {
-		return uuid.UUID{}, false, nil
+		return initiatorInfo{}, false, nil
 	}
 	identityID := metadataValue(md, identityIDMetadataKey)
-	if identityID == "" {
-		return uuid.UUID{}, false, nil
+	identityType := metadataValue(md, identityTypeMetadataKey)
+	if identityID == "" || identityType == "" {
+		return initiatorInfo{}, false, nil
 	}
 	initiatorID, err := parseUUID(identityID)
 	if err != nil {
-		return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+		return initiatorInfo{}, false, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-	return initiatorID, true, nil
+	passive := strings.EqualFold(identityType, agentIdentityType)
+	return initiatorInfo{ID: initiatorID, Passive: passive}, true, nil
 }
 
 func metadataValue(md metadata.MD, key string) string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -19,6 +19,7 @@ import (
 
 type stubThreadStore struct {
 	t                *testing.T
+	createThreadFn   func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error)
 	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 }
 
@@ -27,9 +28,12 @@ func (s *stubThreadStore) unexpectedCall(method string) {
 	s.t.Fatalf("unexpected %s call", method)
 }
 
-func (s *stubThreadStore) CreateThread(context.Context, []uuid.UUID) (store.Thread, error) {
-	s.unexpectedCall("CreateThread")
-	return store.Thread{}, nil
+func (s *stubThreadStore) CreateThread(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+	s.t.Helper()
+	if s.createThreadFn == nil {
+		s.t.Fatalf("unexpected CreateThread call")
+	}
+	return s.createThreadFn(ctx, participants)
 }
 
 func (s *stubThreadStore) ArchiveThread(context.Context, uuid.UUID) (store.Thread, error) {
@@ -94,6 +98,162 @@ func (s *stubAgentsService) GetAgent(ctx context.Context, req *agentsv1.GetAgent
 		s.t.Fatalf("unexpected GetAgent call")
 	}
 	return s.getAgentFn(ctx, req, opts...)
+}
+
+func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
+	threadID := uuid.New()
+	agentID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			if len(participants) != 2 {
+				t.Fatalf("expected 2 participants, got %d", len(participants))
+			}
+			agentInput := findParticipantInput(participants, agentID)
+			if agentInput == nil {
+				t.Fatalf("expected agent participant %s", agentID)
+			}
+			if !agentInput.Passive {
+				t.Fatalf("expected agent passive true")
+			}
+			participantInput := findParticipantInput(participants, participantID)
+			if participantInput == nil {
+				t.Fatalf("expected participant %s", participantID)
+			}
+			if participantInput.Passive {
+				t.Fatalf("expected participant passive false")
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: agentID, JoinedAt: now, Passive: true},
+					{ID: participantID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{agentID.String(), participantID.String()}})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	agentParticipant := findProtoParticipant(resp.GetThread(), agentID)
+	if agentParticipant == nil {
+		t.Fatal("expected agent participant in response")
+	}
+	if !agentParticipant.GetPassive() {
+		t.Fatal("expected agent participant passive true")
+	}
+}
+
+func TestCreateThreadUserInitiatorActive(t *testing.T) {
+	threadID := uuid.New()
+	userID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			for _, participant := range participants {
+				if participant.Passive {
+					t.Fatalf("expected passive false for participant %s", participant.ID)
+				}
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: userID, JoinedAt: now, Passive: false},
+					{ID: participantID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user"),
+	)
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{userID.String(), participantID.String()}})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	userParticipant := findProtoParticipant(resp.GetThread(), userID)
+	if userParticipant == nil {
+		t.Fatal("expected user participant in response")
+	}
+	if userParticipant.GetPassive() {
+		t.Fatal("expected user participant passive false")
+	}
+}
+
+func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
+	threadID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			for _, participant := range participants {
+				if participant.Passive {
+					t.Fatalf("expected passive false for participant %s", participant.ID)
+				}
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: participantID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil)
+	resp, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	participant := findProtoParticipant(resp.GetThread(), participantID)
+	if participant == nil {
+		t.Fatal("expected participant in response")
+	}
+	if participant.GetPassive() {
+		t.Fatal("expected participant passive false")
+	}
 }
 
 func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
@@ -491,4 +651,26 @@ func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
 	if st.Code() != codes.Internal {
 		t.Fatalf("expected Internal, got %s: %s", st.Code(), st.Message())
 	}
+}
+
+func findParticipantInput(participants []store.ParticipantInput, id uuid.UUID) *store.ParticipantInput {
+	for i := range participants {
+		if participants[i].ID == id {
+			return &participants[i]
+		}
+	}
+	return nil
+}
+
+func findProtoParticipant(thread *threadsv1.Thread, id uuid.UUID) *threadsv1.Participant {
+	if thread == nil {
+		return nil
+	}
+	value := id.String()
+	for _, participant := range thread.GetParticipants() {
+		if participant.GetId() == value {
+			return participant
+		}
+	}
+	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -687,15 +687,6 @@ func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
 	}
 }
 
-func findParticipantInput(participants []store.ParticipantInput, id uuid.UUID) *store.ParticipantInput {
-	for i := range participants {
-		if participants[i].ID == id {
-			return &participants[i]
-		}
-	}
-	return nil
-}
-
 func findProtoParticipant(thread *threadsv1.Thread, id uuid.UUID) *threadsv1.Participant {
 	if thread == nil {
 		return nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -114,18 +114,16 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 			if len(participants) != 2 {
 				t.Fatalf("expected 2 participants, got %d", len(participants))
 			}
-			agentInput := findParticipantInput(participants, agentID)
-			if agentInput == nil {
-				t.Fatalf("expected agent participant %s", agentID)
+			if participants[0].ID != agentID {
+				t.Fatalf("expected initiator %s first, got %s", agentID, participants[0].ID)
 			}
-			if !agentInput.Passive {
+			if !participants[0].Passive {
 				t.Fatalf("expected agent passive true")
 			}
-			participantInput := findParticipantInput(participants, participantID)
-			if participantInput == nil {
-				t.Fatalf("expected participant %s", participantID)
+			if participants[1].ID != participantID {
+				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
 			}
-			if participantInput.Passive {
+			if participants[1].Passive {
 				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
@@ -146,7 +144,7 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
 	)
-	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{agentID.String(), participantID.String()}})
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
 	if err != nil {
 		t.Fatalf("CreateThread returned error: %v", err)
 	}
@@ -173,10 +171,20 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 		t: t,
 		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
-			for _, participant := range participants {
-				if participant.Passive {
-					t.Fatalf("expected passive false for participant %s", participant.ID)
-				}
+			if len(participants) != 2 {
+				t.Fatalf("expected 2 participants, got %d", len(participants))
+			}
+			if participants[0].ID != userID {
+				t.Fatalf("expected initiator %s first, got %s", userID, participants[0].ID)
+			}
+			if participants[0].Passive {
+				t.Fatalf("expected initiator passive false")
+			}
+			if participants[1].ID != participantID {
+				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
+			}
+			if participants[1].Passive {
+				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
 				ID:        threadID,
@@ -196,7 +204,7 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 		context.Background(),
 		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user"),
 	)
-	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{userID.String(), participantID.String()}})
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
 	if err != nil {
 		t.Fatalf("CreateThread returned error: %v", err)
 	}
@@ -222,10 +230,14 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 		t: t,
 		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
-			for _, participant := range participants {
-				if participant.Passive {
-					t.Fatalf("expected passive false for participant %s", participant.ID)
-				}
+			if len(participants) != 1 {
+				t.Fatalf("expected 1 participant, got %d", len(participants))
+			}
+			if participants[0].ID != participantID {
+				t.Fatalf("expected participant %s, got %s", participantID, participants[0].ID)
+			}
+			if participants[0].Passive {
+				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
 				ID:        threadID,
@@ -253,6 +265,28 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 	}
 	if participant.GetPassive() {
 		t.Fatal("expected participant passive false")
+	}
+}
+
+func TestCreateThreadRejectsInitiatorInParticipants(t *testing.T) {
+	initiatorID := uuid.New()
+	participantID := uuid.New()
+
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", initiatorID.String(), "x-identity-type", "agent"),
+	)
+	_, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{initiatorID.String(), participantID.String()}})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
 	}
 }
 

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (s *Store) CreateThread(ctx context.Context, participantIDs []uuid.UUID) (Thread, error) {
+func (s *Store) CreateThread(ctx context.Context, participantInputs []ParticipantInput) (Thread, error) {
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		threadID := uuid.New()
@@ -19,12 +19,12 @@ func (s *Store) CreateThread(ctx context.Context, participantIDs []uuid.UUID) (T
 		if _, err := tx.Exec(ctx, `INSERT INTO threads (id, status, created_at, updated_at) VALUES ($1, $2, $3, $3)`, threadID, int16(ThreadStatusActive), now); err != nil {
 			return err
 		}
-		participants := make([]Participant, len(participantIDs))
-		for i, participantID := range participantIDs {
-			if _, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at, passive) VALUES ($1, $2, $3, $4)`, threadID, participantID, now, false); err != nil {
+		participants := make([]Participant, len(participantInputs))
+		for i, participant := range participantInputs {
+			if _, err := tx.Exec(ctx, `INSERT INTO thread_participants (thread_id, participant_id, joined_at, passive) VALUES ($1, $2, $3, $4)`, threadID, participant.ID, now, participant.Passive); err != nil {
 				return err
 			}
-			participants[i] = Participant{ID: participantID, JoinedAt: now, Passive: false}
+			participants[i] = Participant{ID: participant.ID, JoinedAt: now, Passive: participant.Passive}
 		}
 		thread = Thread{
 			ID:           threadID,

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -44,6 +44,11 @@ type Participant struct {
 	Passive  bool
 }
 
+type ParticipantInput struct {
+	ID      uuid.UUID
+	Passive bool
+}
+
 type Message struct {
 	ID        uuid.UUID
 	ThreadID  uuid.UUID


### PR DESCRIPTION
## Summary
- mark agent initiators as passive during CreateThread based on identity metadata
- keep non-agent initiators active while preserving default behavior for missing metadata
- add server tests covering agent/user/missing identity metadata cases

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
- go vet ./...
- go test ./...
- go build ./...

Fixes #18