### PR TITLE
fix(server): allow initiator-only threads

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,7 +71,11 @@ func New(store threadStore, notifier notifierPublisher, identity identityResolve
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
 	ids := req.GetParticipantIds()
-	if len(ids) == 0 {
+	initiator, hasInitiator, err := initiatorInfoFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 && !hasInitiator {
 		return nil, status.Error(codes.InvalidArgument, "participant_ids must be provided")
 	}
 	participantIDs := make([]uuid.UUID, len(ids))
@@ -88,10 +92,6 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 		participantIDs[i] = id
 	}
 
-	initiator, hasInitiator, err := initiatorInfoFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 	if hasInitiator {
 		if _, ok := seen[initiator.ID]; ok {
 			return nil, status.Error(codes.InvalidArgument, "participant_ids must not include initiator")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,14 +90,9 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: %v", i, err)
 			}
-			if hasInitiator && id == initiator.ID {
-				return nil, status.Error(codes.InvalidArgument, "participant_ids must not include initiator")
+			if err := addResolvedParticipant(id, initiator, hasInitiator, seen, &resolved, "participant_ids", i); err != nil {
+				return nil, err
 			}
-			if _, ok := seen[id]; ok {
-				return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: duplicate participant", i)
-			}
-			seen[id] = struct{}{}
-			resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
 		}
 	}
 	if len(identifiers) > 0 {
@@ -113,14 +108,9 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "participants[%d].participant_id: %v", i, err)
 				}
-				if hasInitiator && id == initiator.ID {
-					return nil, status.Error(codes.InvalidArgument, "participants must not include initiator")
+				if err := addResolvedParticipant(id, initiator, hasInitiator, seen, &resolved, "participants", i); err != nil {
+					return nil, err
 				}
-				if _, ok := seen[id]; ok {
-					return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: duplicate participant", i)
-				}
-				seen[id] = struct{}{}
-				resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
 			case *threadsv1.ParticipantIdentifier_ParticipantNickname:
 				if !organizationResolved {
 					orgID, err := s.organizationIDForNickname(ctx, req.OrganizationId)
@@ -134,14 +124,9 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 				if err != nil {
 					return nil, err
 				}
-				if hasInitiator && id == initiator.ID {
-					return nil, status.Error(codes.InvalidArgument, "participants must not include initiator")
+				if err := addResolvedParticipant(id, initiator, hasInitiator, seen, &resolved, "participants", i); err != nil {
+					return nil, err
 				}
-				if _, ok := seen[id]; ok {
-					return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: duplicate participant", i)
-				}
-				seen[id] = struct{}{}
-				resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
 			default:
 				return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: identifier must be provided", i)
 			}
@@ -163,6 +148,18 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 	}
 	s.recordThreadCreated(ctx, thread)
 	return &threadsv1.CreateThreadResponse{Thread: toProtoThread(thread)}, nil
+}
+
+func addResolvedParticipant(id uuid.UUID, initiator initiatorInfo, hasInitiator bool, seen map[uuid.UUID]struct{}, resolved *[]store.ParticipantInput, fieldName string, index int) error {
+	if hasInitiator && id == initiator.ID {
+		return status.Errorf(codes.InvalidArgument, "%s must not include initiator", fieldName)
+	}
+	if _, ok := seen[id]; ok {
+		return status.Errorf(codes.InvalidArgument, "%s[%d]: duplicate participant", fieldName, index)
+	}
+	seen[id] = struct{}{}
+	*resolved = append(*resolved, store.ParticipantInput{ID: id, Passive: false})
+	return nil
 }
 
 func (s *Server) ArchiveThread(ctx context.Context, req *threadsv1.ArchiveThreadRequest) (*threadsv1.ArchiveThreadResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,34 +70,84 @@ func New(store threadStore, notifier notifierPublisher, identity identityResolve
 }
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
-	ids := req.GetParticipantIds()
 	initiator, hasInitiator, err := initiatorInfoFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(ids) == 0 && !hasInitiator {
-		return nil, status.Error(codes.InvalidArgument, "participant_ids must be provided")
+	ids := req.GetParticipantIds()
+	identifiers := req.GetParticipants()
+	if len(ids) > 0 && len(identifiers) > 0 {
+		return nil, status.Error(codes.InvalidArgument, "participant_ids and participants are mutually exclusive")
 	}
-	participantIDs := make([]uuid.UUID, len(ids))
-	seen := make(map[uuid.UUID]struct{}, len(ids))
-	for i, raw := range ids {
-		id, err := parseUUID(raw)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: %v", i, err)
-		}
-		if _, ok := seen[id]; ok {
-			return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: duplicate participant", i)
-		}
-		seen[id] = struct{}{}
-		participantIDs[i] = id
+	if len(ids) == 0 && len(identifiers) == 0 && !hasInitiator {
+		return nil, status.Error(codes.InvalidArgument, "participant_ids or participants must be provided")
 	}
-
-	if hasInitiator {
-		if _, ok := seen[initiator.ID]; ok {
-			return nil, status.Error(codes.InvalidArgument, "participant_ids must not include initiator")
+	seen := make(map[uuid.UUID]struct{}, len(ids)+len(identifiers))
+	resolved := make([]store.ParticipantInput, 0, len(ids)+len(identifiers))
+	if len(ids) > 0 {
+		for i, raw := range ids {
+			id, err := parseUUID(strings.TrimSpace(raw))
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: %v", i, err)
+			}
+			if hasInitiator && id == initiator.ID {
+				return nil, status.Error(codes.InvalidArgument, "participant_ids must not include initiator")
+			}
+			if _, ok := seen[id]; ok {
+				return nil, status.Errorf(codes.InvalidArgument, "participant_ids[%d]: duplicate participant", i)
+			}
+			seen[id] = struct{}{}
+			resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
 		}
 	}
-	capacity := len(participantIDs)
+	if len(identifiers) > 0 {
+		var organizationID uuid.UUID
+		organizationResolved := false
+		for i, identifier := range identifiers {
+			if identifier == nil {
+				return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: identifier must be provided", i)
+			}
+			switch value := identifier.GetIdentifier().(type) {
+			case *threadsv1.ParticipantIdentifier_ParticipantId:
+				id, err := parseUUID(strings.TrimSpace(value.ParticipantId))
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "participants[%d].participant_id: %v", i, err)
+				}
+				if hasInitiator && id == initiator.ID {
+					return nil, status.Error(codes.InvalidArgument, "participants must not include initiator")
+				}
+				if _, ok := seen[id]; ok {
+					return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: duplicate participant", i)
+				}
+				seen[id] = struct{}{}
+				resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
+			case *threadsv1.ParticipantIdentifier_ParticipantNickname:
+				if !organizationResolved {
+					orgID, err := s.organizationIDForNickname(ctx, req.OrganizationId)
+					if err != nil {
+						return nil, err
+					}
+					organizationID = orgID
+					organizationResolved = true
+				}
+				id, err := s.resolveNickname(ctx, organizationID, value.ParticipantNickname, fmt.Sprintf("participants[%d].participant_nickname", i))
+				if err != nil {
+					return nil, err
+				}
+				if hasInitiator && id == initiator.ID {
+					return nil, status.Error(codes.InvalidArgument, "participants must not include initiator")
+				}
+				if _, ok := seen[id]; ok {
+					return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: duplicate participant", i)
+				}
+				seen[id] = struct{}{}
+				resolved = append(resolved, store.ParticipantInput{ID: id, Passive: false})
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: identifier must be provided", i)
+			}
+		}
+	}
+	capacity := len(resolved)
 	if hasInitiator {
 		capacity++
 	}
@@ -105,9 +155,7 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 	if hasInitiator {
 		participants = append(participants, store.ParticipantInput{ID: initiator.ID, Passive: initiator.Passive})
 	}
-	for _, participantID := range participantIDs {
-		participants = append(participants, store.ParticipantInput{ID: participantID, Passive: false})
-	}
+	participants = append(participants, resolved...)
 
 	thread, err := s.store.CreateThread(ctx, participants)
 	if err != nil {
@@ -363,7 +411,7 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 			}
 			return participantID, nil
 		case *threadsv1.ParticipantIdentifier_ParticipantNickname:
-			return s.resolveParticipantNickname(ctx, req, value.ParticipantNickname)
+			return s.resolveAddParticipantNickname(ctx, req.OrganizationId, value.ParticipantNickname)
 		default:
 			return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
 		}
@@ -378,18 +426,22 @@ func (s *Server) resolveParticipantID(ctx context.Context, req *threadsv1.AddPar
 	return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant identifier must be provided")
 }
 
-func (s *Server) resolveParticipantNickname(ctx context.Context, req *threadsv1.AddParticipantRequest, nickname string) (uuid.UUID, error) {
+func (s *Server) resolveAddParticipantNickname(ctx context.Context, organizationIDValue *string, nickname string) (uuid.UUID, error) {
+	organizationID, err := s.organizationIDForNickname(ctx, organizationIDValue)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return s.resolveNickname(ctx, organizationID, nickname, "participant.participant_nickname")
+}
+
+func (s *Server) resolveNickname(ctx context.Context, organizationID uuid.UUID, nickname string, fieldName string) (uuid.UUID, error) {
 	trimmed := strings.TrimSpace(nickname)
 	if trimmed == "" {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s must be provided", fieldName)
 	}
 	cleaned := strings.TrimPrefix(trimmed, "@")
 	if cleaned == "" {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "participant.participant_nickname must be provided")
-	}
-	organizationID, err := s.organizationIDForNickname(ctx, req)
-	if err != nil {
-		return uuid.UUID{}, err
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s must be provided", fieldName)
 	}
 	response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
 		OrganizationId: organizationID.String(),
@@ -405,9 +457,9 @@ func (s *Server) resolveParticipantNickname(ctx context.Context, req *threadsv1.
 	return participantID, nil
 }
 
-func (s *Server) organizationIDForNickname(ctx context.Context, req *threadsv1.AddParticipantRequest) (uuid.UUID, error) {
-	if req.OrganizationId != nil {
-		organizationID, err := parseUUID(strings.TrimSpace(req.GetOrganizationId()))
+func (s *Server) organizationIDForNickname(ctx context.Context, organizationIDValue *string) (uuid.UUID, error) {
+	if organizationIDValue != nil {
+		organizationID, err := parseUUID(strings.TrimSpace(*organizationIDValue))
 		if err != nil {
 			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -144,7 +144,11 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
 	)
-	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantId{ParticipantId: participantID.String()}},
+		},
+	})
 	if err != nil {
 		t.Fatalf("CreateThread returned error: %v", err)
 	}
@@ -320,6 +324,157 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 	}
 }
 
+func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+	identityCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			if len(participants) != 1 {
+				t.Fatalf("expected 1 participant, got %d", len(participants))
+			}
+			if participants[0].ID != participantID {
+				t.Fatalf("expected participant %s, got %s", participantID, participants[0].ID)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: participantID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-delta" {
+				t.Fatalf("expected nickname agent-delta, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, identityStub, nil, nil)
+	orgIDValue := organizationID.String()
+	resp, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
+		OrganizationId: &orgIDValue,
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-delta"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected ResolveNickname to be called")
+	}
+	if resp.GetThread() == nil || len(resp.GetThread().GetParticipants()) != 1 {
+		t.Fatalf("expected 1 participant, got %v", resp.GetThread().GetParticipants())
+	}
+}
+
+func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	participantID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+	identityCalled := false
+	agentCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			if len(participants) != 2 {
+				t.Fatalf("expected 2 participants, got %d", len(participants))
+			}
+			if participants[0].ID != agentID {
+				t.Fatalf("expected initiator %s first, got %s", agentID, participants[0].ID)
+			}
+			if !participants[0].Passive {
+				t.Fatalf("expected initiator passive true")
+			}
+			if participants[1].ID != participantID {
+				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: agentID, JoinedAt: now, Passive: true},
+					{ID: participantID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-epsilon" {
+				t.Fatalf("expected nickname agent-epsilon, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		getAgentFn: func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+			agentCalled = true
+			if req.GetId() != agentID.String() {
+				t.Fatalf("expected agent ID %s, got %s", agentID, req.GetId())
+			}
+			return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{OrganizationId: organizationID.String()}}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, identityStub, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	_, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-epsilon"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	if !agentCalled {
+		t.Fatal("expected GetAgent to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected ResolveNickname to be called")
+	}
+}
+
 func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
 	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
 	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{})
@@ -332,6 +487,37 @@ func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
 	}
 	if st.Code() != codes.InvalidArgument {
 		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "participant_ids or participants must be provided" {
+		t.Fatalf("expected participant error, got %s", st.Message())
+	}
+}
+
+func TestCreateThreadNicknameRequiresOrganizationIDForUser(t *testing.T) {
+	userID := uuid.New()
+
+	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user"),
+	)
+	_, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "organization_id must be provided for participant_nickname" {
+		t.Fatalf("expected organization_id error, got %s", st.Message())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -160,6 +160,58 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 	}
 }
 
+func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
+	threadID := uuid.New()
+	agentID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			if len(participants) != 1 {
+				t.Fatalf("expected 1 participant, got %d", len(participants))
+			}
+			if participants[0].ID != agentID {
+				t.Fatalf("expected initiator %s, got %s", agentID, participants[0].ID)
+			}
+			if !participants[0].Passive {
+				t.Fatalf("expected initiator passive true")
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: agentID, JoinedAt: now, Passive: true},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+	)
+	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	agentParticipant := findProtoParticipant(resp.GetThread(), agentID)
+	if agentParticipant == nil {
+		t.Fatal("expected agent participant in response")
+	}
+	if !agentParticipant.GetPassive() {
+		t.Fatal("expected agent participant passive true")
+	}
+}
+
 func TestCreateThreadUserInitiatorActive(t *testing.T) {
 	threadID := uuid.New()
 	userID := uuid.New()
@@ -265,6 +317,21 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 	}
 	if participant.GetPassive() {
 		t.Fatal("expected participant passive false")
+	}
+}
+
+func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -475,6 +475,74 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 	}
 }
 
+func TestCreateThreadMixedParticipantIdentifiers(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	participantID := uuid.New()
+	nicknameID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+	identityCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+			storeCalled = true
+			if len(participants) != 2 {
+				t.Fatalf("expected 2 participants, got %d", len(participants))
+			}
+			if participants[0].ID != participantID {
+				t.Fatalf("expected participant %s first, got %s", participantID, participants[0].ID)
+			}
+			if participants[1].ID != nicknameID {
+				t.Fatalf("expected participant %s second, got %s", nicknameID, participants[1].ID)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Participants: []store.Participant{
+					{ID: participantID, JoinedAt: now, Passive: false},
+					{ID: nicknameID, JoinedAt: now, Passive: false},
+				},
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			if req.GetNickname() != "agent-zeta" {
+				t.Fatalf("expected nickname agent-zeta, got %s", req.GetNickname())
+			}
+			return &identityv1.ResolveNicknameResponse{IdentityId: nicknameID.String()}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, identityStub, nil, nil)
+	orgIDValue := organizationID.String()
+	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
+		OrganizationId: &orgIDValue,
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantId{ParticipantId: participantID.String()}},
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-zeta"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected ResolveNickname to be called")
+	}
+}
+
 func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
 	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
 	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{})
@@ -490,6 +558,31 @@ func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
 	}
 	if st.Message() != "participant_ids or participants must be provided" {
 		t.Fatalf("expected participant error, got %s", st.Message())
+	}
+}
+
+func TestCreateThreadRejectsMixedParticipantFields(t *testing.T) {
+	participantID := uuid.New()
+
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
+		ParticipantIds: []string{participantID.String()},
+		Participants: []*threadsv1.ParticipantIdentifier{
+			{Identifier: &threadsv1.ParticipantIdentifier_ParticipantId{ParticipantId: participantID.String()}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "participant_ids and participants are mutually exclusive" {
+		t.Fatalf("expected mutual exclusivity error, got %s", st.Message())
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow CreateThread to accept empty participant_ids when initiator metadata is present
- add tests for initiator-only thread creation and missing metadata rejection

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
- go vet ./...
- go test ./...
- go build ./...

Fixes #20