### PR TITLE
feat(threads): add org thread access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
 
       - name: Run tests
         run: go test ./...

--- a/cmd/threads/main.go
+++ b/cmd/threads/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/threads/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	meteringv1 "github.com/agynio/threads/.gen/go/agynio/api/metering/v1"
 	notificationsv1 "github.com/agynio/threads/.gen/go/agynio/api/notifications/v1"
@@ -62,6 +63,12 @@ func run() error {
 	}
 	defer notificationsConn.Close()
 
+	authorizationConn, err := grpc.DialContext(ctx, cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial authorization: %w", err)
+	}
+	defer authorizationConn.Close()
+
 	identityConn, err := grpc.DialContext(ctx, cfg.IdentityAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial identity: %w", err)
@@ -86,6 +93,7 @@ func run() error {
 		server.New(
 			store.NewStore(pool),
 			notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
+			authorizationv1.NewAuthorizationServiceClient(authorizationConn),
 			identityv1.NewIdentityServiceClient(identityConn),
 			agentsv1.NewAgentsServiceClient(agentsConn),
 			metering.New(meteringv1.NewMeteringServiceClient(meteringConn)),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	GRPCAddress            string
 	DatabaseURL            string
 	NotificationsAddress   string
+	AuthorizationAddress   string
 	IdentityAddress        string
 	AgentsServiceAddress   string
 	MeteringServiceAddress string
@@ -27,6 +28,10 @@ func FromEnv() (Config, error) {
 	cfg.NotificationsAddress = os.Getenv("NOTIFICATIONS_ADDRESS")
 	if cfg.NotificationsAddress == "" {
 		cfg.NotificationsAddress = "notifications:50051"
+	}
+	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
+	if cfg.AuthorizationAddress == "" {
+		cfg.AuthorizationAddress = "authorization:50051"
 	}
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ func TestFromEnvDefaults(t *testing.T) {
 	t.Setenv("GRPC_ADDRESS", "")
 	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/threads")
 	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("AUTHORIZATION_ADDRESS", "")
 	t.Setenv("IDENTITY_ADDRESS", "")
 	t.Setenv("METERING_SERVICE_ADDRESS", "")
 
@@ -22,6 +23,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.NotificationsAddress != "notifications:50051" {
 		t.Fatalf("expected notifications address notifications:50051, got %q", cfg.NotificationsAddress)
 	}
+	if cfg.AuthorizationAddress != "authorization:50051" {
+		t.Fatalf("expected authorization address authorization:50051, got %q", cfg.AuthorizationAddress)
+	}
 	if cfg.IdentityAddress != "identity:50051" {
 		t.Fatalf("expected identity address identity:50051, got %q", cfg.IdentityAddress)
 	}
@@ -34,6 +38,7 @@ func TestFromEnvOverrides(t *testing.T) {
 	t.Setenv("GRPC_ADDRESS", "0.0.0.0:9999")
 	t.Setenv("DATABASE_URL", "postgres://user:pass@db:5432/threads")
 	t.Setenv("NOTIFICATIONS_ADDRESS", "notifications.internal:6000")
+	t.Setenv("AUTHORIZATION_ADDRESS", "authorization.internal:6003")
 	t.Setenv("IDENTITY_ADDRESS", "identity.internal:6001")
 	t.Setenv("METERING_SERVICE_ADDRESS", "metering.internal:6002")
 
@@ -47,6 +52,9 @@ func TestFromEnvOverrides(t *testing.T) {
 	if cfg.NotificationsAddress != "notifications.internal:6000" {
 		t.Fatalf("expected notifications address override, got %q", cfg.NotificationsAddress)
 	}
+	if cfg.AuthorizationAddress != "authorization.internal:6003" {
+		t.Fatalf("expected authorization address override, got %q", cfg.AuthorizationAddress)
+	}
 	if cfg.IdentityAddress != "identity.internal:6001" {
 		t.Fatalf("expected identity address override, got %q", cfg.IdentityAddress)
 	}
@@ -59,6 +67,7 @@ func TestFromEnvRequiresDatabaseURL(t *testing.T) {
 	t.Setenv("GRPC_ADDRESS", "")
 	t.Setenv("DATABASE_URL", "")
 	t.Setenv("NOTIFICATIONS_ADDRESS", "")
+	t.Setenv("AUTHORIZATION_ADDRESS", "")
 	t.Setenv("IDENTITY_ADDRESS", "")
 	t.Setenv("METERING_SERVICE_ADDRESS", "")
 

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -9,10 +9,14 @@ import (
 
 func toProtoThread(thread store.Thread) *threadsv1.Thread {
 	protoThread := &threadsv1.Thread{
-		Id:        thread.ID.String(),
-		Status:    toProtoThreadStatus(thread.Status),
-		CreatedAt: timestamppb.New(thread.CreatedAt),
-		UpdatedAt: timestamppb.New(thread.UpdatedAt),
+		Id:           thread.ID.String(),
+		Status:       toProtoThreadStatus(thread.Status),
+		CreatedAt:    timestamppb.New(thread.CreatedAt),
+		UpdatedAt:    timestamppb.New(thread.UpdatedAt),
+		MessageCount: thread.MessageCount,
+	}
+	if thread.OrganizationID != nil {
+		protoThread.OrganizationId = thread.OrganizationID.String()
 	}
 	if len(thread.Participants) > 0 {
 		protoThread.Participants = make([]*threadsv1.Participant, len(thread.Participants))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -327,16 +327,16 @@ func (s *Server) GetThread(ctx context.Context, req *threadsv1.GetThreadRequest)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
 	}
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	thread, err := s.store.GetThread(ctx, threadID)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
 	if thread.OrganizationID == nil {
 		return nil, status.Error(codes.NotFound, store.ErrThreadNotFound.Error())
-	}
-	identityID, err := identityIDFromContext(ctx)
-	if err != nil {
-		return nil, err
 	}
 	if err := s.checkCanViewThreads(ctx, identityID, *thread.OrganizationID); err != nil {
 		return nil, err
@@ -554,19 +554,36 @@ func (s *Server) organizationIDForThread(ctx context.Context, organizationIDValu
 }
 
 func (s *Server) organizationIDForRequest(ctx context.Context, organizationIDValue *string, missingMessage string) (uuid.UUID, error) {
+	var requestedID *uuid.UUID
 	if organizationIDValue != nil {
 		organizationID, err := parseUUID(strings.TrimSpace(*organizationIDValue))
 		if err != nil {
 			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 		}
-		return organizationID, nil
+		requestedID = &organizationID
 	}
 	organizationID, ok, err := organizationIDFromContext(ctx)
 	if err != nil {
 		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	if ok {
+		if requestedID != nil && *requestedID != organizationID {
+			return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id does not match identity organization")
+		}
 		return organizationID, nil
+	}
+	if requestedID != nil {
+		if isAgentIdentity(ctx) {
+			identityOrgID, err := s.organizationIDFromIdentity(ctx, missingMessage)
+			if err != nil {
+				return uuid.UUID{}, err
+			}
+			if identityOrgID != *requestedID {
+				return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id does not match identity organization")
+			}
+			return identityOrgID, nil
+		}
+		return *requestedID, nil
 	}
 	return s.organizationIDFromIdentity(ctx, missingMessage)
 }
@@ -636,6 +653,15 @@ func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
 	return parsedID, nil
+}
+
+func isAgentIdentity(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	identityType := metadataValue(md, identityTypeMetadataKey)
+	return strings.EqualFold(identityType, agentIdentityType)
 }
 
 func (s *Server) checkCanViewThreads(ctx context.Context, identityID, organizationID uuid.UUID) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/threads/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -22,11 +23,12 @@ import (
 
 type Server struct {
 	threadsv1.UnimplementedThreadsServiceServer
-	store    threadStore
-	notifier notifierPublisher
-	identity identityResolver
-	agents   agentsService
-	metering meteringRecorder
+	store         threadStore
+	notifier      notifierPublisher
+	authorization authorizationChecker
+	identity      identityResolver
+	agents        agentsService
+	metering      meteringRecorder
 }
 
 const (
@@ -35,15 +37,19 @@ const (
 	identityTypeMetadataKey   = "x-identity-type"
 	agentIdentityType         = "agent"
 	meteringTimeout           = 5 * time.Second
+	identityObjectPrefix      = "identity:"
+	organizationObjectPrefix  = "organization:"
 )
 
 type threadStore interface {
-	CreateThread(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error)
+	CreateThread(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
 	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
+	GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *store.ThreadCursor) (store.ThreadListResult, error)
-	ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
+	ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
 	ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
 	AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
 }
@@ -56,6 +62,10 @@ type agentsService interface {
 	GetAgent(ctx context.Context, in *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
 }
 
+type authorizationChecker interface {
+	Check(ctx context.Context, in *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
+}
+
 type notifierPublisher interface {
 	PublishMessageCreated(ctx context.Context, threadID, messageID uuid.UUID, recipients []uuid.UUID) error
 }
@@ -65,8 +75,8 @@ type meteringRecorder interface {
 	RecordMessageSent(ctx context.Context, orgID, threadID, messageID uuid.UUID, createdAt time.Time) error
 }
 
-func New(store threadStore, notifier notifierPublisher, identity identityResolver, agents agentsService, metering meteringRecorder) *Server {
-	return &Server{store: store, notifier: notifier, identity: identity, agents: agents, metering: metering}
+func New(store threadStore, notifier notifierPublisher, authorization authorizationChecker, identity identityResolver, agents agentsService, metering meteringRecorder) *Server {
+	return &Server{store: store, notifier: notifier, authorization: authorization, identity: identity, agents: agents, metering: metering}
 }
 
 func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
@@ -95,9 +105,9 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 			}
 		}
 	}
+	var organizationID uuid.UUID
+	organizationResolved := false
 	if len(identifiers) > 0 {
-		var organizationID uuid.UUID
-		organizationResolved := false
 		for i, identifier := range identifiers {
 			if identifier == nil {
 				return nil, status.Errorf(codes.InvalidArgument, "participants[%d]: identifier must be provided", i)
@@ -132,6 +142,13 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 			}
 		}
 	}
+	if !organizationResolved {
+		orgID, err := s.organizationIDForThread(ctx, req.OrganizationId)
+		if err != nil {
+			return nil, err
+		}
+		organizationID = orgID
+	}
 	capacity := len(resolved)
 	if hasInitiator {
 		capacity++
@@ -142,7 +159,7 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 	}
 	participants = append(participants, resolved...)
 
-	thread, err := s.store.CreateThread(ctx, participants)
+	thread, err := s.store.CreateThread(ctx, organizationID, participants)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -257,10 +274,88 @@ func (s *Server) GetThreads(ctx context.Context, req *threadsv1.GetThreadsReques
 	return resp, nil
 }
 
+func (s *Server) ListOrganizationThreads(ctx context.Context, req *threadsv1.ListOrganizationThreadsRequest) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkCanViewThreads(ctx, identityID, organizationID); err != nil {
+		return nil, err
+	}
+
+	var statusFilter *store.ThreadStatus
+	if req.Status != nil {
+		parsed, err := threadStatusFromProto(req.GetStatus())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "status: %v", err)
+		}
+		statusFilter = &parsed
+	}
+
+	var cursor *store.OrganizationThreadCursor
+	if token := req.GetPageToken(); token != "" {
+		tokenOrgID, tokenCursor, err := store.DecodeOrganizationThreadPageToken(token)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+		}
+		if tokenOrgID != organizationID {
+			return nil, status.Error(codes.InvalidArgument, "page_token does not match organization")
+		}
+		cursor = &tokenCursor
+	}
+
+	result, err := s.store.ListOrganizationThreads(ctx, organizationID, statusFilter, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	resp := &threadsv1.ListOrganizationThreadsResponse{Threads: make([]*threadsv1.Thread, len(result.Threads))}
+	for i, thread := range result.Threads {
+		resp.Threads[i] = toProtoThread(thread)
+	}
+	if result.NextCursor != nil {
+		token, err := store.EncodeOrganizationThreadPageToken(organizationID, *result.NextCursor)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "encode page token: %v", err)
+		}
+		resp.NextPageToken = token
+	}
+	return resp, nil
+}
+
+func (s *Server) GetThread(ctx context.Context, req *threadsv1.GetThreadRequest) (*threadsv1.GetThreadResponse, error) {
+	threadID, err := parseUUID(req.GetThreadId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
+	}
+	thread, err := s.store.GetThread(ctx, threadID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if thread.OrganizationID == nil {
+		return nil, status.Error(codes.NotFound, store.ErrThreadNotFound.Error())
+	}
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkCanViewThreads(ctx, identityID, *thread.OrganizationID); err != nil {
+		return nil, err
+	}
+	return &threadsv1.GetThreadResponse{Thread: toProtoThread(thread)}, nil
+}
+
 func (s *Server) GetMessages(ctx context.Context, req *threadsv1.GetMessagesRequest) (*threadsv1.GetMessagesResponse, error) {
 	threadID, err := parseUUID(req.GetThreadId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
+	}
+	order, err := messageOrderFromProto(req.GetOrder())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "order: %v", err)
 	}
 	var cursor *store.MessageCursor
 	if token := req.GetPageToken(); token != "" {
@@ -274,7 +369,7 @@ func (s *Server) GetMessages(ctx context.Context, req *threadsv1.GetMessagesRequ
 		cursor = &tokenCursor
 	}
 
-	result, err := s.store.ListMessages(ctx, threadID, req.GetPageSize(), cursor)
+	result, err := s.store.ListMessages(ctx, threadID, req.GetPageSize(), cursor, order)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -455,6 +550,14 @@ func (s *Server) resolveNickname(ctx context.Context, organizationID uuid.UUID, 
 }
 
 func (s *Server) organizationIDForNickname(ctx context.Context, organizationIDValue *string) (uuid.UUID, error) {
+	return s.organizationIDForRequest(ctx, organizationIDValue, "organization_id must be provided for participant_nickname")
+}
+
+func (s *Server) organizationIDForThread(ctx context.Context, organizationIDValue *string) (uuid.UUID, error) {
+	return s.organizationIDForRequest(ctx, organizationIDValue, "organization_id must be provided")
+}
+
+func (s *Server) organizationIDForRequest(ctx context.Context, organizationIDValue *string, missingMessage string) (uuid.UUID, error) {
 	if organizationIDValue != nil {
 		organizationID, err := parseUUID(strings.TrimSpace(*organizationIDValue))
 		if err != nil {
@@ -469,7 +572,7 @@ func (s *Server) organizationIDForNickname(ctx context.Context, organizationIDVa
 	if ok {
 		return organizationID, nil
 	}
-	return s.organizationIDFromIdentity(ctx)
+	return s.organizationIDFromIdentity(ctx, missingMessage)
 }
 
 func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
@@ -488,18 +591,18 @@ func organizationIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
 	return orgID, true, nil
 }
 
-func (s *Server) organizationIDFromIdentity(ctx context.Context) (uuid.UUID, error) {
+func (s *Server) organizationIDFromIdentity(ctx context.Context, missingMessage string) (uuid.UUID, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, missingMessage)
 	}
 	identityID := metadataValue(md, identityIDMetadataKey)
 	identityType := metadataValue(md, identityTypeMetadataKey)
 	if identityID == "" || identityType == "" {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, missingMessage)
 	}
 	if !strings.EqualFold(identityType, agentIdentityType) {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "organization_id must be provided for participant_nickname")
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, missingMessage)
 	}
 	if s.agents == nil {
 		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
@@ -521,6 +624,66 @@ func (s *Server) organizationIDFromIdentity(ctx context.Context) (uuid.UUID, err
 		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent organization_id: %v", err)
 	}
 	return orgID, nil
+}
+
+func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, status.Error(codes.Unauthenticated, "identity not available")
+	}
+	identityID := metadataValue(md, identityIDMetadataKey)
+	if identityID == "" {
+		return uuid.UUID{}, status.Error(codes.Unauthenticated, "identity not available")
+	}
+	parsedID, err := parseUUID(identityID)
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	return parsedID, nil
+}
+
+func (s *Server) checkCanViewThreads(ctx context.Context, identityID, organizationID uuid.UUID) error {
+	if s.authorization == nil {
+		return status.Error(codes.Internal, "authorization service not configured")
+	}
+	response, err := s.authorization.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+			Relation: "can_view_threads",
+			Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+		},
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !response.GetAllowed() {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return nil
+}
+
+func threadStatusFromProto(status threadsv1.ThreadStatus) (store.ThreadStatus, error) {
+	switch status {
+	case threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE:
+		return store.ThreadStatusActive, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED:
+		return store.ThreadStatusArchived, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_UNSPECIFIED:
+		return store.ThreadStatusUnspecified, errors.New("status must be set")
+	default:
+		return store.ThreadStatusUnspecified, errors.New("invalid thread status")
+	}
+}
+
+func messageOrderFromProto(order threadsv1.MessageOrder) (store.MessageOrder, error) {
+	switch order {
+	case threadsv1.MessageOrder_MESSAGE_ORDER_UNSPECIFIED, threadsv1.MessageOrder_MESSAGE_ORDER_OLDEST_FIRST:
+		return store.MessageOrderOldestFirst, nil
+	case threadsv1.MessageOrder_MESSAGE_ORDER_NEWEST_FIRST:
+		return store.MessageOrderNewestFirst, nil
+	default:
+		return store.MessageOrderOldestFirst, errors.New("invalid message order")
+	}
 }
 
 type initiatorInfo struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -274,7 +274,7 @@ func (s *Server) GetThreads(ctx context.Context, req *threadsv1.GetThreadsReques
 	return resp, nil
 }
 
-func (s *Server) ListOrganizationThreads(ctx context.Context, req *threadsv1.ListOrganizationThreadsRequest) (*threadsv1.ListOrganizationThreadsResponse, error) {
+func (s *Server) GetOrganizationThreads(ctx context.Context, req *threadsv1.GetOrganizationThreadsRequest) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
@@ -287,13 +287,9 @@ func (s *Server) ListOrganizationThreads(ctx context.Context, req *threadsv1.Lis
 		return nil, err
 	}
 
-	var statusFilter *store.ThreadStatus
-	if req.Status != nil {
-		parsed, err := threadStatusFromProto(req.GetStatus())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "status: %v", err)
-		}
-		statusFilter = &parsed
+	statusFilter, err := threadStatusFilterFromProto(req.GetStatus())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "status: %v", err)
 	}
 
 	var cursor *store.OrganizationThreadCursor
@@ -312,7 +308,7 @@ func (s *Server) ListOrganizationThreads(ctx context.Context, req *threadsv1.Lis
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	resp := &threadsv1.ListOrganizationThreadsResponse{Threads: make([]*threadsv1.Thread, len(result.Threads))}
+	resp := &threadsv1.GetOrganizationThreadsResponse{Threads: make([]*threadsv1.Thread, len(result.Threads))}
 	for i, thread := range result.Threads {
 		resp.Threads[i] = toProtoThread(thread)
 	}
@@ -662,16 +658,18 @@ func (s *Server) checkCanViewThreads(ctx context.Context, identityID, organizati
 	return nil
 }
 
-func threadStatusFromProto(status threadsv1.ThreadStatus) (store.ThreadStatus, error) {
+func threadStatusFilterFromProto(status threadsv1.ThreadStatus) (*store.ThreadStatus, error) {
 	switch status {
-	case threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE:
-		return store.ThreadStatusActive, nil
-	case threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED:
-		return store.ThreadStatusArchived, nil
 	case threadsv1.ThreadStatus_THREAD_STATUS_UNSPECIFIED:
-		return store.ThreadStatusUnspecified, errors.New("status must be set")
+		return nil, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE:
+		value := store.ThreadStatusActive
+		return &value, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED:
+		value := store.ThreadStatusArchived
+		return &value, nil
 	default:
-		return store.ThreadStatusUnspecified, errors.New("invalid thread status")
+		return nil, errors.New("invalid thread status")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -388,6 +388,33 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 	}
 }
 
+func TestCreateThreadRejectsMismatchedOrganizationID(t *testing.T) {
+	organizationID := uuid.New()
+	otherOrganizationID := uuid.New()
+	participantID := uuid.New()
+	otherOrgValue := otherOrganizationID.String()
+
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
+	_, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
+		OrganizationId: &otherOrgValue,
+		ParticipantIds: []string{participantID.String()},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "organization_id does not match identity organization" {
+		t.Fatalf("expected organization_id mismatch, got %s", st.Message())
+	}
+}
+
 func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 	threadID := uuid.New()
 	organizationID := uuid.New()
@@ -763,7 +790,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 
 	srv := New(storeStub, nil, nil, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", uuid.New().String()))
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
 	resp, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
 		ThreadId:       threadID.String(),
 		OrganizationId: &orgIDValue,
@@ -1236,7 +1263,7 @@ func TestGetOrganizationThreadsPagination(t *testing.T) {
 		t.Fatal("expected authorization check")
 	}
 	if !storeCalled {
-				t.Fatal("expected GetOrganizationThreads to be called")
+		t.Fatal("expected GetOrganizationThreads to be called")
 	}
 	if len(resp.GetThreads()) != 1 {
 		t.Fatalf("expected 1 thread, got %d", len(resp.GetThreads()))
@@ -1298,6 +1325,7 @@ func TestGetThreadAuthorizationDenied(t *testing.T) {
 
 func TestGetThreadMissingOrganizationID(t *testing.T) {
 	threadID := uuid.New()
+	identityID := uuid.New()
 	storeStub := &stubThreadStore{
 		t: t,
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
@@ -1314,7 +1342,8 @@ func TestGetThreadMissingOrganizationID(t *testing.T) {
 	}
 
 	srv := New(storeStub, nil, nil, nil, nil, nil)
-	_, err := srv.GetThread(context.Background(), &threadsv1.GetThreadRequest{ThreadId: threadID.String()})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.GetThread(ctx, &threadsv1.GetThreadRequest{ThreadId: threadID.String()})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/threads/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/threads/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/threads/.gen/go/agynio/api/identity/v1"
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"github.com/google/uuid"
@@ -19,8 +20,11 @@ import (
 
 type stubThreadStore struct {
 	t                *testing.T
-	createThreadFn   func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error)
+	createThreadFn   func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
 	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
+	getThreadFn      func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	listOrgThreadsFn func(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	listMessagesFn   func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
 }
 
 func (s *stubThreadStore) unexpectedCall(method string) {
@@ -28,12 +32,12 @@ func (s *stubThreadStore) unexpectedCall(method string) {
 	s.t.Fatalf("unexpected %s call", method)
 }
 
-func (s *stubThreadStore) CreateThread(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+func (s *stubThreadStore) CreateThread(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 	s.t.Helper()
 	if s.createThreadFn == nil {
 		s.t.Fatalf("unexpected CreateThread call")
 	}
-	return s.createThreadFn(ctx, participants)
+	return s.createThreadFn(ctx, organizationID, participants)
 }
 
 func (s *stubThreadStore) ArchiveThread(context.Context, uuid.UUID) (store.Thread, error) {
@@ -54,14 +58,33 @@ func (s *stubThreadStore) SendMessage(context.Context, uuid.UUID, uuid.UUID, str
 	return store.SendMessageResult{}, nil
 }
 
+func (s *stubThreadStore) GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error) {
+	s.t.Helper()
+	if s.getThreadFn == nil {
+		s.t.Fatalf("unexpected GetThread call")
+	}
+	return s.getThreadFn(ctx, threadID)
+}
+
 func (s *stubThreadStore) ListThreads(context.Context, uuid.UUID, int32, *store.ThreadCursor) (store.ThreadListResult, error) {
 	s.unexpectedCall("ListThreads")
 	return store.ThreadListResult{}, nil
 }
 
-func (s *stubThreadStore) ListMessages(context.Context, uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
-	s.unexpectedCall("ListMessages")
-	return store.MessageListResult{}, nil
+func (s *stubThreadStore) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+	s.t.Helper()
+	if s.listOrgThreadsFn == nil {
+		s.t.Fatalf("unexpected ListOrganizationThreads call")
+	}
+	return s.listOrgThreadsFn(ctx, organizationID, status, pageSize, cursor)
+}
+
+func (s *stubThreadStore) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error) {
+	s.t.Helper()
+	if s.listMessagesFn == nil {
+		s.t.Fatalf("unexpected ListMessages call")
+	}
+	return s.listMessagesFn(ctx, threadID, pageSize, cursor, order)
 }
 
 func (s *stubThreadStore) ListUnackedMessages(context.Context, uuid.UUID, *uuid.UUID, int32, *store.MessageCursor) (store.MessageListResult, error) {
@@ -100,8 +123,22 @@ func (s *stubAgentsService) GetAgent(ctx context.Context, req *agentsv1.GetAgent
 	return s.getAgentFn(ctx, req, opts...)
 }
 
+type stubAuthorizationService struct {
+	t       *testing.T
+	checkFn func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
+}
+
+func (s *stubAuthorizationService) Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	s.t.Helper()
+	if s.checkFn == nil {
+		s.t.Fatalf("unexpected Check call")
+	}
+	return s.checkFn(ctx, req, opts...)
+}
+
 func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 	threadID := uuid.New()
+	organizationID := uuid.New()
 	agentID := uuid.New()
 	participantID := uuid.New()
 	now := time.Now().UTC()
@@ -109,8 +146,11 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 2 {
 				t.Fatalf("expected 2 participants, got %d", len(participants))
 			}
@@ -127,10 +167,12 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: agentID, JoinedAt: now, Passive: true},
 					{ID: participantID, JoinedAt: now, Passive: false},
@@ -139,10 +181,10 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
-		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent", "x-organization-id", organizationID.String()),
 	)
 	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
 		Participants: []*threadsv1.ParticipantIdentifier{
@@ -166,14 +208,18 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 
 func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 	threadID := uuid.New()
+	organizationID := uuid.New()
 	agentID := uuid.New()
 	now := time.Now().UTC()
 	storeCalled := false
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 1 {
 				t.Fatalf("expected 1 participant, got %d", len(participants))
 			}
@@ -184,10 +230,12 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 				t.Fatalf("expected initiator passive true")
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: agentID, JoinedAt: now, Passive: true},
 				},
@@ -195,10 +243,10 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
-		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
+		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent", "x-organization-id", organizationID.String()),
 	)
 	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{})
 	if err != nil {
@@ -218,6 +266,7 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 
 func TestCreateThreadUserInitiatorActive(t *testing.T) {
 	threadID := uuid.New()
+	organizationID := uuid.New()
 	userID := uuid.New()
 	participantID := uuid.New()
 	now := time.Now().UTC()
@@ -225,8 +274,11 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 2 {
 				t.Fatalf("expected 2 participants, got %d", len(participants))
 			}
@@ -243,10 +295,12 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: userID, JoinedAt: now, Passive: false},
 					{ID: participantID, JoinedAt: now, Passive: false},
@@ -255,10 +309,10 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
-		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user"),
+		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user", "x-organization-id", organizationID.String()),
 	)
 	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
 	if err != nil {
@@ -278,14 +332,18 @@ func TestCreateThreadUserInitiatorActive(t *testing.T) {
 
 func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 	threadID := uuid.New()
+	organizationID := uuid.New()
 	participantID := uuid.New()
 	now := time.Now().UTC()
 	storeCalled := false
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 1 {
 				t.Fatalf("expected 1 participant, got %d", len(participants))
 			}
@@ -296,10 +354,12 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 				t.Fatalf("expected participant passive false")
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: participantID, JoinedAt: now, Passive: false},
 				},
@@ -307,8 +367,12 @@ func TestCreateThreadMissingIdentityMetadataDefaultsActive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
-	resp, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{ParticipantIds: []string{participantID.String()}})
+	srv := New(storeStub, nil, nil, nil, nil, nil)
+	orgIDValue := organizationID.String()
+	resp, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
+		OrganizationId: &orgIDValue,
+		ParticipantIds: []string{participantID.String()},
+	})
 	if err != nil {
 		t.Fatalf("CreateThread returned error: %v", err)
 	}
@@ -334,8 +398,11 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 1 {
 				t.Fatalf("expected 1 participant, got %d", len(participants))
 			}
@@ -343,10 +410,12 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 				t.Fatalf("expected participant %s, got %s", participantID, participants[0].ID)
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: participantID, JoinedAt: now, Passive: false},
 				},
@@ -367,7 +436,7 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil, nil)
+	srv := New(storeStub, nil, nil, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
 	resp, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
 		OrganizationId: &orgIDValue,
@@ -401,8 +470,11 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 2 {
 				t.Fatalf("expected 2 participants, got %d", len(participants))
 			}
@@ -416,10 +488,12 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: agentID, JoinedAt: now, Passive: true},
 					{ID: participantID, JoinedAt: now, Passive: false},
@@ -451,7 +525,7 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, agentsStub, nil)
+	srv := New(storeStub, nil, nil, identityStub, agentsStub, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
@@ -486,8 +560,11 @@ func TestCreateThreadMixedParticipantIdentifiers(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		createThreadFn: func(ctx context.Context, participants []store.ParticipantInput) (store.Thread, error) {
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
 			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
 			if len(participants) != 2 {
 				t.Fatalf("expected 2 participants, got %d", len(participants))
 			}
@@ -498,10 +575,12 @@ func TestCreateThreadMixedParticipantIdentifiers(t *testing.T) {
 				t.Fatalf("expected participant %s second, got %s", nicknameID, participants[1].ID)
 			}
 			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				MessageCount:   0,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 				Participants: []store.Participant{
 					{ID: participantID, JoinedAt: now, Passive: false},
 					{ID: nicknameID, JoinedAt: now, Passive: false},
@@ -523,7 +602,7 @@ func TestCreateThreadMixedParticipantIdentifiers(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil, nil)
+	srv := New(storeStub, nil, nil, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
 	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
 		OrganizationId: &orgIDValue,
@@ -544,7 +623,7 @@ func TestCreateThreadMixedParticipantIdentifiers(t *testing.T) {
 }
 
 func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
-	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil, nil)
 	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{})
 	if err == nil {
 		t.Fatal("expected error")
@@ -564,7 +643,7 @@ func TestCreateThreadMissingIdentityMetadataRejectsEmpty(t *testing.T) {
 func TestCreateThreadRejectsMixedParticipantFields(t *testing.T) {
 	participantID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil, nil)
 	_, err := srv.CreateThread(context.Background(), &threadsv1.CreateThreadRequest{
 		ParticipantIds: []string{participantID.String()},
 		Participants: []*threadsv1.ParticipantIdentifier{
@@ -589,7 +668,7 @@ func TestCreateThreadRejectsMixedParticipantFields(t *testing.T) {
 func TestCreateThreadNicknameRequiresOrganizationIDForUser(t *testing.T) {
 	userID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, &stubIdentityResolver{t: t}, nil, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", userID.String(), "x-identity-type", "user"),
@@ -618,7 +697,7 @@ func TestCreateThreadRejectsInitiatorInParticipants(t *testing.T) {
 	initiatorID := uuid.New()
 	participantID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", initiatorID.String(), "x-identity-type", "agent"),
@@ -682,7 +761,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil, nil)
+	srv := New(storeStub, nil, nil, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", uuid.New().String()))
 	resp, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
@@ -732,7 +811,7 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{
@@ -766,7 +845,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, nil, nil, nil)
+	srv := New(storeStub, nil, nil, nil, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId:      threadID.String(),
 		ParticipantId: participantID.String(),
@@ -782,7 +861,7 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 func TestAddParticipantNicknameRequiresOrganizationID(t *testing.T) {
 	threadID := uuid.New()
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, &stubIdentityResolver{t: t}, nil, nil)
 	_, err := srv.AddParticipant(context.Background(), &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
 		Participant: &threadsv1.ParticipantIdentifier{
@@ -838,7 +917,7 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, nil, nil)
+	srv := New(storeStub, nil, nil, identityStub, nil, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String()))
 	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
 		ThreadId: threadID.String(),
@@ -905,7 +984,7 @@ func TestAddParticipantNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T)
 		},
 	}
 
-	srv := New(storeStub, nil, identityStub, agentsStub, nil)
+	srv := New(storeStub, nil, nil, identityStub, agentsStub, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
@@ -937,7 +1016,7 @@ func TestAddParticipantNicknameRejectsNonAgentIdentityTypes(t *testing.T) {
 
 	for _, identityType := range identityTypes {
 		t.Run(identityType, func(t *testing.T) {
-			srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, nil, nil)
+			srv := New(&stubThreadStore{t: t}, nil, nil, &stubIdentityResolver{t: t}, nil, nil)
 			ctx := metadata.NewIncomingContext(
 				context.Background(),
 				metadata.Pairs("x-identity-id", identityID.String(), "x-identity-type", identityType),
@@ -976,7 +1055,7 @@ func TestAddParticipantNicknameAgentLookupError(t *testing.T) {
 		},
 	}
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
@@ -1010,7 +1089,7 @@ func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
 		},
 	}
 
-	srv := New(&stubThreadStore{t: t}, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
+	srv := New(&stubThreadStore{t: t}, nil, nil, &stubIdentityResolver{t: t}, agentsStub, nil)
 	ctx := metadata.NewIncomingContext(
 		context.Background(),
 		metadata.Pairs("x-identity-id", agentID.String(), "x-identity-type", "agent"),
@@ -1030,6 +1109,278 @@ func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
 	}
 	if st.Code() != codes.Internal {
 		t.Fatalf("expected Internal, got %s: %s", st.Code(), st.Message())
+	}
+}
+
+func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authCalled := false
+
+	authStub := &stubAuthorizationService{
+		t: t,
+		checkFn: func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+			authCalled = true
+			if req.GetTupleKey() == nil {
+				t.Fatal("expected tuple key")
+			}
+			if req.GetTupleKey().GetRelation() != "can_view_threads" {
+				t.Fatalf("expected relation can_view_threads, got %s", req.GetTupleKey().GetRelation())
+			}
+			expectedUser := identityObjectPrefix + identityID.String()
+			if req.GetTupleKey().GetUser() != expectedUser {
+				t.Fatalf("expected user %s, got %s", expectedUser, req.GetTupleKey().GetUser())
+			}
+			expectedObject := organizationObjectPrefix + organizationID.String()
+			if req.GetTupleKey().GetObject() != expectedObject {
+				t.Fatalf("expected object %s, got %s", expectedObject, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(&stubThreadStore{t: t}, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{OrganizationId: organizationID.String()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %s: %s", st.Code(), st.Message())
+	}
+	if !authCalled {
+		t.Fatal("expected authorization check")
+	}
+}
+
+func TestListOrganizationThreadsPagination(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	threadID := uuid.New()
+	participantID := uuid.New()
+	createdAt := time.Now().UTC().Add(-2 * time.Hour)
+	updatedAt := createdAt.Add(10 * time.Minute)
+	pageCursor := store.OrganizationThreadCursor{CreatedAt: createdAt.Add(30 * time.Minute), ThreadID: uuid.New()}
+	pageToken, err := store.EncodeOrganizationThreadPageToken(organizationID, pageCursor)
+	if err != nil {
+		t.Fatalf("encode page token: %v", err)
+	}
+	nextCursor := store.OrganizationThreadCursor{CreatedAt: createdAt, ThreadID: threadID}
+	expectedNextToken, err := store.EncodeOrganizationThreadPageToken(organizationID, nextCursor)
+	if err != nil {
+		t.Fatalf("encode next token: %v", err)
+	}
+	storeCalled := false
+	authCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
+			if status != nil {
+				t.Fatalf("expected nil status filter")
+			}
+			if pageSize != 1 {
+				t.Fatalf("expected page size 1, got %d", pageSize)
+			}
+			if cursor == nil {
+				t.Fatal("expected cursor")
+			}
+			if cursor.ThreadID != pageCursor.ThreadID || !cursor.CreatedAt.Equal(pageCursor.CreatedAt) {
+				t.Fatalf("unexpected cursor: %+v", cursor)
+			}
+			return store.OrganizationThreadListResult{
+				Threads: []store.Thread{
+					{
+						ID:             threadID,
+						OrganizationID: &organizationID,
+						MessageCount:   3,
+						Status:         store.ThreadStatusActive,
+						CreatedAt:      createdAt,
+						UpdatedAt:      updatedAt,
+						Participants: []store.Participant{
+							{ID: participantID, JoinedAt: createdAt, Passive: false},
+						},
+					},
+				},
+				NextCursor: &nextCursor,
+			}, nil
+		},
+	}
+	authStub := &stubAuthorizationService{
+		t: t,
+		checkFn: func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+			authCalled = true
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	resp, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{
+		OrganizationId: organizationID.String(),
+		PageSize:       1,
+		PageToken:      pageToken,
+	})
+	if err != nil {
+		t.Fatalf("ListOrganizationThreads returned error: %v", err)
+	}
+	if !authCalled {
+		t.Fatal("expected authorization check")
+	}
+	if !storeCalled {
+		t.Fatal("expected ListOrganizationThreads to be called")
+	}
+	if len(resp.GetThreads()) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(resp.GetThreads()))
+	}
+	if resp.GetThreads()[0].GetId() != threadID.String() {
+		t.Fatalf("expected thread id %s, got %s", threadID, resp.GetThreads()[0].GetId())
+	}
+	if resp.GetNextPageToken() != expectedNextToken {
+		t.Fatalf("expected next page token %s, got %s", expectedNextToken, resp.GetNextPageToken())
+	}
+}
+
+func TestGetThreadAuthorizationDenied(t *testing.T) {
+	organizationID := uuid.New()
+	threadID := uuid.New()
+	identityID := uuid.New()
+	authCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			if id != threadID {
+				t.Fatalf("expected thread id %s, got %s", threadID, id)
+			}
+			return store.Thread{
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      time.Now().UTC(),
+				UpdatedAt:      time.Now().UTC(),
+			}, nil
+		},
+	}
+	authStub := &stubAuthorizationService{
+		t: t,
+		checkFn: func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+			authCalled = true
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.GetThread(ctx, &threadsv1.GetThreadRequest{ThreadId: threadID.String()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %s: %s", st.Code(), st.Message())
+	}
+	if !authCalled {
+		t.Fatal("expected authorization check")
+	}
+}
+
+func TestGetThreadMissingOrganizationID(t *testing.T) {
+	threadID := uuid.New()
+	storeStub := &stubThreadStore{
+		t: t,
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			if id != threadID {
+				t.Fatalf("expected thread id %s, got %s", threadID, id)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil, nil)
+	_, err := srv.GetThread(context.Background(), &threadsv1.GetThreadRequest{ThreadId: threadID.String()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Fatalf("expected NotFound, got %s: %s", st.Code(), st.Message())
+	}
+}
+
+func TestGetMessagesNewestFirst(t *testing.T) {
+	threadID := uuid.New()
+	messageID := uuid.New()
+	senderID := uuid.New()
+	createdAt := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		listMessagesFn: func(ctx context.Context, id uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error) {
+			storeCalled = true
+			if id != threadID {
+				t.Fatalf("expected thread id %s, got %s", threadID, id)
+			}
+			if pageSize != 2 {
+				t.Fatalf("expected page size 2, got %d", pageSize)
+			}
+			if cursor != nil {
+				t.Fatal("expected nil cursor")
+			}
+			if order != store.MessageOrderNewestFirst {
+				t.Fatalf("expected newest-first order, got %v", order)
+			}
+			return store.MessageListResult{
+				Messages: []store.Message{
+					{
+						ID:        messageID,
+						ThreadID:  threadID,
+						SenderID:  senderID,
+						Body:      "hello",
+						CreatedAt: createdAt,
+					},
+				},
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil, nil)
+	resp, err := srv.GetMessages(context.Background(), &threadsv1.GetMessagesRequest{
+		ThreadId: threadID.String(),
+		PageSize: 2,
+		Order:    threadsv1.MessageOrder_MESSAGE_ORDER_NEWEST_FIRST,
+	})
+	if err != nil {
+		t.Fatalf("GetMessages returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected ListMessages to be called")
+	}
+	if len(resp.GetMessages()) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(resp.GetMessages()))
+	}
+	if resp.GetMessages()[0].GetId() != messageID.String() {
+		t.Fatalf("expected message id %s, got %s", messageID, resp.GetMessages()[0].GetId())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1112,7 +1112,7 @@ func TestAddParticipantNicknameAgentMissingOrganization(t *testing.T) {
 	}
 }
 
-func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
+func TestGetOrganizationThreadsAuthorizationDenied(t *testing.T) {
 	organizationID := uuid.New()
 	identityID := uuid.New()
 	authCalled := false
@@ -1141,7 +1141,7 @@ func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
 
 	srv := New(&stubThreadStore{t: t}, nil, authStub, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
-	_, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{OrganizationId: organizationID.String()})
+	_, err := srv.GetOrganizationThreads(ctx, &threadsv1.GetOrganizationThreadsRequest{OrganizationId: organizationID.String()})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1157,7 +1157,7 @@ func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
 	}
 }
 
-func TestListOrganizationThreadsPagination(t *testing.T) {
+func TestGetOrganizationThreadsPagination(t *testing.T) {
 	organizationID := uuid.New()
 	identityID := uuid.New()
 	threadID := uuid.New()
@@ -1224,19 +1224,19 @@ func TestListOrganizationThreadsPagination(t *testing.T) {
 
 	srv := New(storeStub, nil, authStub, nil, nil, nil)
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
-	resp, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{
+	resp, err := srv.GetOrganizationThreads(ctx, &threadsv1.GetOrganizationThreadsRequest{
 		OrganizationId: organizationID.String(),
 		PageSize:       1,
 		PageToken:      pageToken,
 	})
 	if err != nil {
-		t.Fatalf("ListOrganizationThreads returned error: %v", err)
+		t.Fatalf("GetOrganizationThreads returned error: %v", err)
 	}
 	if !authCalled {
 		t.Fatal("expected authorization check")
 	}
 	if !storeCalled {
-		t.Fatal("expected ListOrganizationThreads to be called")
+				t.Fatal("expected GetOrganizationThreads to be called")
 	}
 	if len(resp.GetThreads()) != 1 {
 		t.Fatalf("expected 1 thread, got %d", len(resp.GetThreads()))

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -19,11 +19,11 @@ type SendMessageResult struct {
 func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (SendMessageResult, error) {
 	var result SendMessageResult
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
-		status, _, _, err := loadThreadRow(ctx, tx, threadID, true)
+		thread, err := loadThreadRow(ctx, tx, threadID, true)
 		if err != nil {
 			return err
 		}
-		if status == ThreadStatusArchived {
+		if thread.Status == ThreadStatusArchived {
 			return ErrThreadArchived
 		}
 		var isParticipant bool
@@ -54,7 +54,7 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 				return err
 			}
 		}
-		if _, err := tx.Exec(ctx, `UPDATE threads SET updated_at = $2 WHERE id = $1`, threadID, now); err != nil {
+		if _, err := tx.Exec(ctx, `UPDATE threads SET updated_at = $2, message_count = message_count + 1 WHERE id = $1`, threadID, now); err != nil {
 			return err
 		}
 		result = SendMessageResult{
@@ -97,7 +97,7 @@ func loadRecipients(ctx context.Context, q queryer, threadID, senderID uuid.UUID
 	return recipients, nil
 }
 
-func (s *Store) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *MessageCursor) (MessageListResult, error) {
+func (s *Store) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *MessageCursor, order MessageOrder) (MessageListResult, error) {
 	if err := ensureThreadExists(ctx, s.pool, threadID); err != nil {
 		return MessageListResult{}, err
 	}
@@ -109,11 +109,19 @@ func (s *Store) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize i
 	args := []any{threadID}
 	paramIndex := 2
 	if cursor != nil {
-		query.WriteString(fmt.Sprintf(" AND (created_at, id) > ($%d, $%d)", paramIndex, paramIndex+1))
+		operator := ">"
+		if order == MessageOrderNewestFirst {
+			operator = "<"
+		}
+		query.WriteString(fmt.Sprintf(" AND (created_at, id) %s ($%d, $%d)", operator, paramIndex, paramIndex+1))
 		args = append(args, cursor.CreatedAt, cursor.MessageID)
 		paramIndex += 2
 	}
-	query.WriteString(fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT $%d", paramIndex))
+	orderClause := "ORDER BY created_at ASC, id ASC"
+	if order == MessageOrderNewestFirst {
+		orderClause = "ORDER BY created_at DESC, id DESC"
+	}
+	query.WriteString(fmt.Sprintf(" %s LIMIT $%d", orderClause, paramIndex))
 	args = append(args, int(limit)+1)
 
 	rows, err := s.pool.Query(ctx, query.String(), args...)

--- a/internal/store/pagination.go
+++ b/internal/store/pagination.go
@@ -70,6 +70,51 @@ func DecodeThreadPageToken(token string) (uuid.UUID, ThreadCursor, error) {
 	}, nil
 }
 
+type organizationThreadPageToken struct {
+	OrganizationID string `json:"organization_id"`
+	CreatedAtNanos int64  `json:"created_at_nanos"`
+	ThreadID       string `json:"thread_id"`
+}
+
+func EncodeOrganizationThreadPageToken(organizationID uuid.UUID, cursor OrganizationThreadCursor) (string, error) {
+	payload := organizationThreadPageToken{
+		OrganizationID: organizationID.String(),
+		CreatedAtNanos: cursor.CreatedAt.UnixNano(),
+		ThreadID:       cursor.ThreadID.String(),
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func DecodeOrganizationThreadPageToken(token string) (uuid.UUID, OrganizationThreadCursor, error) {
+	if token == "" {
+		return uuid.UUID{}, OrganizationThreadCursor{}, errors.New("empty token")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("decode token: %w", err)
+	}
+	var payload organizationThreadPageToken
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("unmarshal token: %w", err)
+	}
+	organizationID, err := uuid.Parse(payload.OrganizationID)
+	if err != nil {
+		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("parse organization id: %w", err)
+	}
+	threadID, err := uuid.Parse(payload.ThreadID)
+	if err != nil {
+		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("parse thread id: %w", err)
+	}
+	return organizationID, OrganizationThreadCursor{
+		CreatedAt: time.Unix(0, payload.CreatedAtNanos).UTC(),
+		ThreadID:  threadID,
+	}, nil
+}
+
 type messagePageToken struct {
 	OwnerID        string `json:"owner_id"`
 	CreatedAtNanos int64  `json:"created_at_nanos"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -43,30 +42,23 @@ type queryer interface {
 	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
-func loadThreadRow(ctx context.Context, q queryer, id uuid.UUID, forUpdate bool) (ThreadStatus, time.Time, time.Time, error) {
-	query := "SELECT status, created_at, updated_at FROM threads WHERE id = $1"
+func loadThreadRow(ctx context.Context, q queryer, id uuid.UUID, forUpdate bool) (Thread, error) {
+	query := "SELECT id, status, created_at, updated_at, organization_id, message_count FROM threads WHERE id = $1"
 	if forUpdate {
 		query += " FOR UPDATE"
 	}
-	var statusValue int16
-	var createdAt time.Time
-	var updatedAt time.Time
-	err := q.QueryRow(ctx, query, id).Scan(&statusValue, &createdAt, &updatedAt)
+	thread, err := scanThreadRow(q.QueryRow(ctx, query, id))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ThreadStatusUnspecified, time.Time{}, time.Time{}, ErrThreadNotFound
+			return Thread{}, ErrThreadNotFound
 		}
-		return ThreadStatusUnspecified, time.Time{}, time.Time{}, err
+		return Thread{}, err
 	}
-	status, err := ParseThreadStatus(statusValue)
-	if err != nil {
-		return ThreadStatusUnspecified, time.Time{}, time.Time{}, fmt.Errorf("invalid thread status: %w", err)
-	}
-	return status, createdAt, updatedAt, nil
+	return thread, nil
 }
 
 func loadThread(ctx context.Context, q queryer, id uuid.UUID) (Thread, error) {
-	status, createdAt, updatedAt, err := loadThreadRow(ctx, q, id, false)
+	thread, err := loadThreadRow(ctx, q, id, false)
 	if err != nil {
 		return Thread{}, err
 	}
@@ -74,13 +66,8 @@ func loadThread(ctx context.Context, q queryer, id uuid.UUID) (Thread, error) {
 	if err != nil {
 		return Thread{}, err
 	}
-	return Thread{
-		ID:           id,
-		Status:       status,
-		CreatedAt:    createdAt,
-		UpdatedAt:    updatedAt,
-		Participants: participants,
-	}, nil
+	thread.Participants = participants
+	return thread, nil
 }
 
 func loadParticipants(ctx context.Context, q queryer, threadID uuid.UUID) ([]Participant, error) {
@@ -133,4 +120,27 @@ func stringsToUUIDs(values []string) ([]uuid.UUID, error) {
 		ids[i] = id
 	}
 	return ids, nil
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanThreadRow(scanner rowScanner) (Thread, error) {
+	var thread Thread
+	var statusValue int16
+	var organizationID pgtype.UUID
+	if err := scanner.Scan(&thread.ID, &statusValue, &thread.CreatedAt, &thread.UpdatedAt, &organizationID, &thread.MessageCount); err != nil {
+		return Thread{}, err
+	}
+	status, err := ParseThreadStatus(statusValue)
+	if err != nil {
+		return Thread{}, fmt.Errorf("invalid thread status: %w", err)
+	}
+	thread.Status = status
+	if organizationID.Valid {
+		orgID := uuid.UUID(organizationID.Bytes)
+		thread.OrganizationID = &orgID
+	}
+	return thread, nil
 }

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -11,12 +11,12 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (s *Store) CreateThread(ctx context.Context, participantInputs []ParticipantInput) (Thread, error) {
+func (s *Store) CreateThread(ctx context.Context, organizationID uuid.UUID, participantInputs []ParticipantInput) (Thread, error) {
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		threadID := uuid.New()
 		now := time.Now().UTC()
-		if _, err := tx.Exec(ctx, `INSERT INTO threads (id, status, created_at, updated_at) VALUES ($1, $2, $3, $3)`, threadID, int16(ThreadStatusActive), now); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO threads (id, organization_id, status, created_at, updated_at, message_count) VALUES ($1, $2, $3, $4, $4, 0)`, threadID, organizationID, int16(ThreadStatusActive), now); err != nil {
 			return err
 		}
 		participants := make([]Participant, len(participantInputs))
@@ -27,11 +27,13 @@ func (s *Store) CreateThread(ctx context.Context, participantInputs []Participan
 			participants[i] = Participant{ID: participant.ID, JoinedAt: now, Passive: participant.Passive}
 		}
 		thread = Thread{
-			ID:           threadID,
-			Status:       ThreadStatusActive,
-			CreatedAt:    now,
-			UpdatedAt:    now,
-			Participants: participants,
+			ID:             threadID,
+			OrganizationID: &organizationID,
+			MessageCount:   0,
+			Status:         ThreadStatusActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			Participants:   participants,
 		}
 		return nil
 	})
@@ -45,9 +47,9 @@ func (s *Store) ArchiveThread(ctx context.Context, threadID uuid.UUID) (Thread, 
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		now := time.Now().UTC()
-		var createdAt time.Time
-		var updatedAt time.Time
-		if err := tx.QueryRow(ctx, `UPDATE threads SET status = $2, updated_at = $3 WHERE id = $1 RETURNING created_at, updated_at`, threadID, int16(ThreadStatusArchived), now).Scan(&createdAt, &updatedAt); err != nil {
+		row := tx.QueryRow(ctx, `UPDATE threads SET status = $2, updated_at = $3 WHERE id = $1 RETURNING id, status, created_at, updated_at, organization_id, message_count`, threadID, int16(ThreadStatusArchived), now)
+		threadRow, err := scanThreadRow(row)
+		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrThreadNotFound
 			}
@@ -57,13 +59,8 @@ func (s *Store) ArchiveThread(ctx context.Context, threadID uuid.UUID) (Thread, 
 		if err != nil {
 			return err
 		}
-		thread = Thread{
-			ID:           threadID,
-			Status:       ThreadStatusArchived,
-			CreatedAt:    createdAt,
-			UpdatedAt:    updatedAt,
-			Participants: participants,
-		}
+		thread = threadRow
+		thread.Participants = participants
 		return nil
 	})
 	if err != nil {
@@ -75,11 +72,11 @@ func (s *Store) ArchiveThread(ctx context.Context, threadID uuid.UUID) (Thread, 
 func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (Thread, error) {
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
-		status, createdAt, updatedAt, err := loadThreadRow(ctx, tx, threadID, true)
+		threadRow, err := loadThreadRow(ctx, tx, threadID, true)
 		if err != nil {
 			return err
 		}
-		if status == ThreadStatusArchived {
+		if threadRow.Status == ThreadStatusArchived {
 			return ErrThreadArchived
 		}
 		now := time.Now().UTC()
@@ -91,19 +88,14 @@ func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid
 			if _, err := tx.Exec(ctx, `UPDATE threads SET updated_at = $2 WHERE id = $1`, threadID, now); err != nil {
 				return err
 			}
-			updatedAt = now
+			threadRow.UpdatedAt = now
 		}
 		participants, err := loadParticipants(ctx, tx, threadID)
 		if err != nil {
 			return err
 		}
-		thread = Thread{
-			ID:           threadID,
-			Status:       status,
-			CreatedAt:    createdAt,
-			UpdatedAt:    updatedAt,
-			Participants: participants,
-		}
+		thread = threadRow
+		thread.Participants = participants
 		return nil
 	})
 	if err != nil {
@@ -115,7 +107,7 @@ func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid
 func (s *Store) ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *ThreadCursor) (ThreadListResult, error) {
 	limit := normalizePageSize(pageSize)
 	query := strings.Builder{}
-	query.WriteString(`SELECT t.id, t.status, t.created_at, t.updated_at
+	query.WriteString(`SELECT t.id, t.status, t.created_at, t.updated_at, t.organization_id, t.message_count
         FROM threads t
         JOIN thread_participants tp ON tp.thread_id = t.id
         WHERE tp.participant_id = $1`)
@@ -143,20 +135,14 @@ func (s *Store) ListThreads(ctx context.Context, participantID uuid.UUID, pageSi
 		hasMore    bool
 	)
 	for rows.Next() {
-		var thread Thread
-		var statusValue int16
-		if err := rows.Scan(&thread.ID, &statusValue, &thread.CreatedAt, &thread.UpdatedAt); err != nil {
+		thread, err := scanThreadRow(rows)
+		if err != nil {
 			return ThreadListResult{}, err
 		}
 		if int32(len(threads)) == limit {
 			hasMore = true
 			break
 		}
-		status, err := ParseThreadStatus(statusValue)
-		if err != nil {
-			return ThreadListResult{}, fmt.Errorf("invalid thread status: %w", err)
-		}
-		thread.Status = status
 		threads = append(threads, thread)
 		lastID = thread.ID
 		lastTime = thread.UpdatedAt
@@ -177,4 +163,77 @@ func (s *Store) ListThreads(ctx context.Context, participantID uuid.UUID, pageSi
 	}
 
 	return ThreadListResult{Threads: threads, NextCursor: nextCursor}, nil
+}
+
+func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *ThreadStatus, pageSize int32, cursor *OrganizationThreadCursor) (OrganizationThreadListResult, error) {
+	limit := normalizePageSize(pageSize)
+	query := strings.Builder{}
+	query.WriteString(`SELECT id, status, created_at, updated_at, organization_id, message_count
+        FROM threads
+        WHERE organization_id = $1`)
+	args := []any{organizationID}
+	paramIndex := 2
+	if status != nil {
+		query.WriteString(fmt.Sprintf(" AND status = $%d", paramIndex))
+		args = append(args, int16(*status))
+		paramIndex++
+	}
+	if cursor != nil {
+		query.WriteString(fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", paramIndex, paramIndex+1))
+		args = append(args, cursor.CreatedAt, cursor.ThreadID)
+		paramIndex += 2
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", paramIndex))
+	args = append(args, int(limit)+1)
+
+	rows, err := s.pool.Query(ctx, query.String(), args...)
+	if err != nil {
+		return OrganizationThreadListResult{}, err
+	}
+	defer rows.Close()
+
+	threads := make([]Thread, 0, limit)
+	var (
+		nextCursor *OrganizationThreadCursor
+		lastID     uuid.UUID
+		lastTime   time.Time
+		hasMore    bool
+	)
+	for rows.Next() {
+		thread, err := scanThreadRow(rows)
+		if err != nil {
+			return OrganizationThreadListResult{}, err
+		}
+		if int32(len(threads)) == limit {
+			hasMore = true
+			break
+		}
+		threads = append(threads, thread)
+		lastID = thread.ID
+		lastTime = thread.CreatedAt
+	}
+	if err := rows.Err(); err != nil {
+		return OrganizationThreadListResult{}, err
+	}
+	if hasMore {
+		nextCursor = &OrganizationThreadCursor{CreatedAt: lastTime, ThreadID: lastID}
+	}
+
+	for i := range threads {
+		participants, err := loadParticipants(ctx, s.pool, threads[i].ID)
+		if err != nil {
+			return OrganizationThreadListResult{}, err
+		}
+		threads[i].Participants = participants
+	}
+
+	return OrganizationThreadListResult{Threads: threads, NextCursor: nextCursor}, nil
+}
+
+func (s *Store) GetThread(ctx context.Context, threadID uuid.UUID) (Thread, error) {
+	thread, err := loadThread(ctx, s.pool, threadID)
+	if err != nil {
+		return Thread{}, err
+	}
+	return thread, nil
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -31,11 +31,13 @@ func ParseThreadStatus(value int16) (ThreadStatus, error) {
 }
 
 type Thread struct {
-	ID           uuid.UUID
-	Participants []Participant
-	Status       ThreadStatus
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID             uuid.UUID
+	OrganizationID *uuid.UUID
+	MessageCount   int32
+	Participants   []Participant
+	Status         ThreadStatus
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 type Participant struct {
@@ -58,8 +60,20 @@ type Message struct {
 	CreatedAt time.Time
 }
 
+type MessageOrder int
+
+const (
+	MessageOrderOldestFirst MessageOrder = iota
+	MessageOrderNewestFirst
+)
+
 type ThreadCursor struct {
 	UpdatedAt time.Time
+	ThreadID  uuid.UUID
+}
+
+type OrganizationThreadCursor struct {
+	CreatedAt time.Time
 	ThreadID  uuid.UUID
 }
 
@@ -71,6 +85,11 @@ type MessageCursor struct {
 type ThreadListResult struct {
 	Threads    []Thread
 	NextCursor *ThreadCursor
+}
+
+type OrganizationThreadListResult struct {
+	Threads    []Thread
+	NextCursor *OrganizationThreadCursor
 }
 
 type MessageListResult struct {

--- a/migrations/0003_add_thread_org_message_count.sql
+++ b/migrations/0003_add_thread_org_message_count.sql
@@ -1,5 +1,6 @@
 ALTER TABLE threads
     ADD COLUMN organization_id UUID,
+    -- message_count remains at 0 for existing rows; new writes update counts.
     ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0;
 
 CREATE INDEX idx_threads_organization_created_at ON threads (organization_id, created_at DESC, id DESC);

--- a/migrations/0003_add_thread_org_message_count.sql
+++ b/migrations/0003_add_thread_org_message_count.sql
@@ -1,0 +1,5 @@
+ALTER TABLE threads
+    ADD COLUMN organization_id UUID,
+    ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_threads_organization_created_at ON threads (organization_id, created_at DESC, id DESC);


### PR DESCRIPTION
## Summary
- add thread organization/message count persistence with migration and store updates
- implement org-scoped thread list/detail with authorization checks and pagination
- support newest-first message ordering and updated thread proto fields

## Testing
- buf generate ../api
- go vet ./...
- go test ./...
- go build ./...

#67