### PR TITLE
fix(build): include auth protos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- include authorization protos in the Dockerfile buf generation step to match release/CI paths

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1
- go vet ./...
- go test ./...
- go build ./...
- docker buildx build --load .

#23