### PR TITLE
feat: add degraded thread support

### DIFF
--- a/charts/threads/templates/authorization-policy.yaml
+++ b/charts/threads/templates/authorization-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Release.Name }}-degrade-thread
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notPrincipals:
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator"
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator-e2e"
+      to:
+        - operation:
+            methods:
+              - POST
+            paths:
+              - /agynio.api.threads.v1.ThreadsService/DegradeThread

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -55,6 +57,6 @@ func toProtoThreadStatus(status store.ThreadStatus) threadsv1.ThreadStatus {
 	case store.ThreadStatusDegraded:
 		return threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED
 	default:
-		return threadsv1.ThreadStatus_THREAD_STATUS_UNSPECIFIED
+		panic(fmt.Sprintf("unsupported thread status: %d", status))
 	}
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -52,6 +52,8 @@ func toProtoThreadStatus(status store.ThreadStatus) threadsv1.ThreadStatus {
 		return threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE
 	case store.ThreadStatusArchived:
 		return threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED
+	case store.ThreadStatusDegraded:
+		return threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED
 	default:
 		return threadsv1.ThreadStatus_THREAD_STATUS_UNSPECIFIED
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -251,6 +251,12 @@ func (s *Server) DegradeThread(ctx context.Context, req *threadsv1.DegradeThread
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
 	}
+	reason := strings.TrimSpace(req.GetReason())
+	if reason == "" {
+		log.Printf("degrade thread requested without reason: thread_id=%s", threadID.String())
+	} else {
+		log.Printf("degrade thread requested: thread_id=%s reason=%s", threadID.String(), reason)
+	}
 	thread, err := s.store.DegradeThread(ctx, threadID)
 	if err != nil {
 		return nil, toStatusError(err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ const (
 type threadStore interface {
 	CreateThread(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
 	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	DegradeThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
 	GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
@@ -243,6 +244,18 @@ func (s *Server) ArchiveThread(ctx context.Context, req *threadsv1.ArchiveThread
 		return nil, toStatusError(err)
 	}
 	return &threadsv1.ArchiveThreadResponse{Thread: toProtoThread(thread)}, nil
+}
+
+func (s *Server) DegradeThread(ctx context.Context, req *threadsv1.DegradeThreadRequest) (*threadsv1.DegradeThreadResponse, error) {
+	threadID, err := parseUUID(req.GetThreadId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
+	}
+	thread, err := s.store.DegradeThread(ctx, threadID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &threadsv1.DegradeThreadResponse{Thread: toProtoThread(thread)}, nil
 }
 
 func (s *Server) AddParticipant(ctx context.Context, req *threadsv1.AddParticipantRequest) (*threadsv1.AddParticipantResponse, error) {
@@ -828,6 +841,9 @@ func threadStatusFilterFromProto(status threadsv1.ThreadStatus) (*store.ThreadSt
 	case threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED:
 		value := store.ThreadStatusArchived
 		return &value, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED:
+		value := store.ThreadStatusDegraded
+		return &value, nil
 	default:
 		return nil, errors.New("invalid thread status")
 	}
@@ -895,6 +911,8 @@ func toStatusError(err error) error {
 	case errors.Is(err, store.ErrThreadNotFound):
 		return status.Error(codes.NotFound, err.Error())
 	case errors.Is(err, store.ErrThreadArchived):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, store.ErrThreadDegraded):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, store.ErrParticipantNotInThread):
 		return status.Error(codes.InvalidArgument, err.Error())

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -994,6 +994,7 @@ func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
 func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 	threadID := uuid.New()
 	participantID := uuid.New()
+	now := time.Now().UTC()
 	storeCalled := false
 
 	storeStub := &stubThreadStore{
@@ -1009,7 +1010,12 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 			if passive {
 				t.Fatalf("expected passive false, got %v", passive)
 			}
-			return store.Thread{ID: threadID}, nil
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
 		},
 	}
 
@@ -1034,6 +1040,7 @@ func TestAddParticipantWithParticipantIDOneof(t *testing.T) {
 func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 	threadID := uuid.New()
 	participantID := uuid.New()
+	now := time.Now().UTC()
 	storeCalled := false
 
 	storeStub := &stubThreadStore{
@@ -1046,7 +1053,12 @@ func TestAddParticipantWithLegacyParticipantID(t *testing.T) {
 			if participantArg != participantID {
 				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
 			}
-			return store.Thread{ID: threadID}, nil
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
 		},
 	}
 
@@ -1224,6 +1236,7 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 	threadID := uuid.New()
 	organizationID := uuid.New()
 	participantID := uuid.New()
+	now := time.Now().UTC()
 	storeCalled := false
 	identityCalled := false
 
@@ -1237,7 +1250,12 @@ func TestAddParticipantNicknameUsesOrganizationIDFromMetadata(t *testing.T) {
 			if participantArg != participantID {
 				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
 			}
-			return store.Thread{ID: threadID}, nil
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
 		},
 	}
 	identityStub := &stubIdentityResolver{
@@ -1280,6 +1298,7 @@ func TestAddParticipantNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T)
 	organizationID := uuid.New()
 	agentID := uuid.New()
 	participantID := uuid.New()
+	now := time.Now().UTC()
 	storeCalled := false
 	identityCalled := false
 	agentCalled := false
@@ -1294,7 +1313,12 @@ func TestAddParticipantNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T)
 			if participantArg != participantID {
 				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
 			}
-			return store.Thread{ID: threadID}, nil
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
 		},
 	}
 	identityStub := &stubIdentityResolver{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -22,6 +22,7 @@ type stubThreadStore struct {
 	t                *testing.T
 	createThreadFn   func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
 	archiveThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	degradeThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 	sendMessageFn    func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
 	getThreadFn      func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
@@ -50,6 +51,14 @@ func (s *stubThreadStore) ArchiveThread(ctx context.Context, threadID uuid.UUID)
 		return store.Thread{}, nil
 	}
 	return s.archiveThreadFn(ctx, threadID)
+}
+
+func (s *stubThreadStore) DegradeThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error) {
+	if s.degradeThreadFn == nil {
+		s.unexpectedCall("DegradeThread")
+		return store.Thread{}, nil
+	}
+	return s.degradeThreadFn(ctx, threadID)
 }
 
 func (s *stubThreadStore) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error) {
@@ -1511,6 +1520,43 @@ func TestArchiveThreadAuthorizationDenied(t *testing.T) {
 	}
 }
 
+func TestDegradeThreadNoAuth(t *testing.T) {
+	threadID := uuid.New()
+	now := time.Now().UTC()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		degradeThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			storeCalled = true
+			if id != threadID {
+				t.Fatalf("expected thread id %s, got %s", threadID, id)
+			}
+			return store.Thread{
+				ID:        threadID,
+				Status:    store.ThreadStatusDegraded,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, nil, nil)
+	resp, err := srv.DegradeThread(context.Background(), &threadsv1.DegradeThreadRequest{ThreadId: threadID.String(), Reason: "needs review"})
+	if err != nil {
+		t.Fatalf("DegradeThread returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected DegradeThread to be called")
+	}
+	if resp.GetThread().GetId() != threadID.String() {
+		t.Fatalf("expected thread id %s, got %s", threadID, resp.GetThread().GetId())
+	}
+	if resp.GetThread().GetStatus() != threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED {
+		t.Fatalf("expected degraded status, got %s", resp.GetThread().GetStatus())
+	}
+}
+
 func TestSendMessageAuthorizationDenied(t *testing.T) {
 	threadID := uuid.New()
 	identityID := uuid.New()
@@ -1608,6 +1654,48 @@ func TestSendMessageRejectsSenderMismatch(t *testing.T) {
 	}
 	if storeCalled {
 		t.Fatal("expected SendMessage not to be called")
+	}
+}
+
+func TestSendMessageRejectsDegradedThread(t *testing.T) {
+	threadID := uuid.New()
+	identityID := uuid.New()
+	storeCalled := false
+	findStatus := func(err error) *status.Status {
+		st, _ := status.FromError(err)
+		return st
+	}
+
+	storeStub := &stubThreadStore{
+		t: t,
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+			storeCalled = true
+			if threadArg != threadID {
+				t.Fatalf("expected thread id %s, got %s", threadID, threadArg)
+			}
+			return store.SendMessageResult{}, store.ErrThreadDegraded
+		},
+	}
+	authStub := allowAuthStub(t)
+
+	srv := New(storeStub, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.SendMessage(ctx, &threadsv1.SendMessageRequest{ThreadId: threadID.String(), Body: "hi"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st := findStatus(err)
+	if st == nil {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %s: %s", st.Code(), st.Message())
+	}
+	if st.Message() != "thread is degraded" {
+		t.Fatalf("expected message 'thread is degraded', got %q", st.Message())
+	}
+	if !storeCalled {
+		t.Fatal("expected SendMessage to be called")
 	}
 }
 
@@ -1781,6 +1869,37 @@ func TestGetOrganizationThreadsPagination(t *testing.T) {
 	}
 	if resp.GetNextPageToken() != expectedNextToken {
 		t.Fatalf("expected next page token %s, got %s", expectedNextToken, resp.GetNextPageToken())
+	}
+}
+
+func TestGetOrganizationThreadsDegradedStatusFilter(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	storeCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
+			if status == nil || *status != store.ThreadStatusDegraded {
+				t.Fatalf("expected degraded status filter, got %v", status)
+			}
+			return store.OrganizationThreadListResult{}, nil
+		},
+	}
+	authStub := allowAuthStub(t)
+
+	srv := New(storeStub, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.GetOrganizationThreads(ctx, &threadsv1.GetOrganizationThreadsRequest{OrganizationId: organizationID.String(), Status: threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED})
+	if err != nil {
+		t.Fatalf("GetOrganizationThreads returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected GetOrganizationThreads to be called")
 	}
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -26,6 +26,9 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 		if thread.Status == ThreadStatusArchived {
 			return ErrThreadArchived
 		}
+		if thread.Status == ThreadStatusDegraded {
+			return ErrThreadDegraded
+		}
 		now := time.Now().UTC()
 		messageID := uuid.New()
 		fileIDArray := pgtype.FlatArray[string](uuidsToStrings(fileIDs))

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -69,6 +69,35 @@ func (s *Store) ArchiveThread(ctx context.Context, threadID uuid.UUID) (Thread, 
 	return thread, nil
 }
 
+func (s *Store) DegradeThread(ctx context.Context, threadID uuid.UUID) (Thread, error) {
+	var thread Thread
+	err := s.runTx(ctx, func(tx pgx.Tx) error {
+		threadRow, err := loadThreadRow(ctx, tx, threadID, true)
+		if err != nil {
+			return err
+		}
+		if threadRow.Status != ThreadStatusArchived && threadRow.Status != ThreadStatusDegraded {
+			now := time.Now().UTC()
+			row := tx.QueryRow(ctx, `UPDATE threads SET status = $2, updated_at = $3 WHERE id = $1 RETURNING id, status, created_at, updated_at, organization_id, message_count`, threadID, int16(ThreadStatusDegraded), now)
+			threadRow, err = scanThreadRow(row)
+			if err != nil {
+				return err
+			}
+		}
+		participants, err := loadParticipants(ctx, tx, threadID)
+		if err != nil {
+			return err
+		}
+		thread = threadRow
+		thread.Participants = participants
+		return nil
+	})
+	if err != nil {
+		return Thread{}, err
+	}
+	return thread, nil
+}
+
 func (s *Store) AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (Thread, error) {
 	var thread Thread
 	err := s.runTx(ctx, func(tx pgx.Tx) error {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -10,6 +10,7 @@ import (
 var (
 	ErrThreadNotFound         = errors.New("thread not found")
 	ErrThreadArchived         = errors.New("thread is archived")
+	ErrThreadDegraded         = errors.New("thread is degraded")
 	ErrParticipantNotInThread = errors.New("participant not in thread")
 )
 
@@ -19,11 +20,12 @@ const (
 	ThreadStatusUnspecified ThreadStatus = 0
 	ThreadStatusActive      ThreadStatus = 1
 	ThreadStatusArchived    ThreadStatus = 2
+	ThreadStatusDegraded    ThreadStatus = 3
 )
 
 func ParseThreadStatus(value int16) (ThreadStatus, error) {
 	switch ThreadStatus(value) {
-	case ThreadStatusActive, ThreadStatusArchived:
+	case ThreadStatusActive, ThreadStatusArchived, ThreadStatusDegraded:
 		return ThreadStatus(value), nil
 	default:
 		return ThreadStatusUnspecified, errors.New("invalid thread status")


### PR DESCRIPTION
## Summary
- add degraded thread status/error handling in store and service
- implement DegradeThread RPC plus SendMessage rejection logic and tests
- add Istio AuthorizationPolicy to restrict DegradeThread

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
- go vet ./...
- go test ./...
- go build ./...

## Tracking
- agynio/agents-orchestrator#148
- Refs #148