### PR TITLE
feat(threads): add list org threads

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1
+                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/authorization/v1 --path agynio/api/agents/v1
                   exec go run ./cmd/threads
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=threads-e2e" \
         -n ${THREADS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/authorization/v1 --path agynio/api/agents/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	threadsv1 "github.com/agynio/threads/.gen/go/agynio/api/threads/v1"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/threads/internal/store"
@@ -29,6 +30,21 @@ func toProtoThread(thread store.Thread) *threadsv1.Thread {
 				Passive:  participant.Passive,
 			}
 		}
+	}
+	return protoThread
+}
+
+func toProtoThreadWithNicknames(thread store.Thread, nicknames map[uuid.UUID]string) *threadsv1.Thread {
+	protoThread := toProtoThread(thread)
+	if len(thread.Participants) == 0 || len(nicknames) == 0 {
+		return protoThread
+	}
+	for i, participant := range thread.Participants {
+		nickname, ok := nicknames[participant.ID]
+		if !ok {
+			continue
+		}
+		protoThread.Participants[i].Nickname = nickname
 	}
 	return protoThread
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -732,7 +732,11 @@ func (s *Server) resolveNickname(ctx context.Context, organizationID uuid.UUID, 
 	if cleaned == "" {
 		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "%s must be provided", fieldName)
 	}
-	response, err := s.identity.ResolveNickname(ctx, &identityv1.ResolveNicknameRequest{
+	identityCtx, err := identityClientContext(ctx)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	response, err := s.identity.ResolveNickname(identityCtx, &identityv1.ResolveNicknameRequest{
 		OrganizationId: organizationID.String(),
 		Nickname:       cleaned,
 	})
@@ -1104,7 +1108,11 @@ func (s *Server) batchResolveNicknames(ctx context.Context, organizationID uuid.
 	}
 	sort.Strings(identityIDs)
 
-	response, err := s.identity.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+	identityCtx, err := identityClientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	response, err := s.identity.BatchGetNicknames(identityCtx, &identityv1.BatchGetNicknamesRequest{
 		OrganizationId: organizationID.String(),
 		IdentityIds:    identityIDs,
 	})
@@ -1159,6 +1167,27 @@ func metadataValue(md metadata.MD, key string) string {
 		return trimmed
 	}
 	return ""
+}
+
+func identityClientContext(ctx context.Context) (context.Context, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "identity not available")
+	}
+	identityID := metadataValue(md, identityIDMetadataKey)
+	if identityID == "" {
+		return nil, status.Error(codes.Unauthenticated, "identity not available")
+	}
+	outgoing := metadata.MD{identityIDMetadataKey: []string{identityID}}
+	identityType := metadataValue(md, identityTypeMetadataKey)
+	if identityType != "" {
+		outgoing[identityTypeMetadataKey] = []string{identityType}
+	}
+	organizationID := metadataValue(md, organizationIDMetadataKey)
+	if organizationID != "" {
+		outgoing[organizationIDMetadataKey] = []string{organizationID}
+	}
+	return metadata.NewOutgoingContext(ctx, outgoing), nil
 }
 
 func parseUUID(value string) (uuid.UUID, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -50,7 +51,7 @@ type threadStore interface {
 	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
 	GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *store.ThreadCursor) (store.ThreadListResult, error)
-	ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
 	ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
 	ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
 	AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
@@ -58,6 +59,7 @@ type threadStore interface {
 
 type identityResolver interface {
 	ResolveNickname(ctx context.Context, in *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
+	BatchGetNicknames(ctx context.Context, in *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error)
 }
 
 type agentsService interface {
@@ -383,6 +385,67 @@ func (s *Server) GetThreads(ctx context.Context, req *threadsv1.GetThreadsReques
 	return resp, nil
 }
 
+func (s *Server) ListOrganizationThreads(ctx context.Context, req *threadsv1.ListOrganizationThreadsRequest) (*threadsv1.ListOrganizationThreadsResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkCanViewThreads(ctx, identityID, organizationID); err != nil {
+		return nil, err
+	}
+
+	filter, err := listOrganizationThreadsFilterFromProto(req.GetFilter())
+	if err != nil {
+		return nil, err
+	}
+	sortSpec, err := listOrganizationThreadsSortFromProto(req.GetSort())
+	if err != nil {
+		return nil, err
+	}
+
+	var cursor *store.OrganizationThreadCursor
+	if token := req.GetPageToken(); token != "" {
+		tokenOrgID, tokenFilter, tokenSort, tokenCursor, err := store.DecodeOrganizationThreadPageToken(token)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+		}
+		if tokenOrgID != organizationID {
+			return nil, status.Error(codes.InvalidArgument, "page_token does not match organization")
+		}
+		if !organizationThreadFilterEqual(tokenFilter, filter) || !organizationThreadSortEqual(tokenSort, sortSpec) {
+			return nil, status.Error(codes.InvalidArgument, "page_token does not match request")
+		}
+		cursor = &tokenCursor
+	}
+
+	result, err := s.store.ListOrganizationThreads(ctx, organizationID, filter, sortSpec, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	nicknames, err := s.batchResolveNicknames(ctx, organizationID, result.Threads)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &threadsv1.ListOrganizationThreadsResponse{Threads: make([]*threadsv1.Thread, len(result.Threads))}
+	for i, thread := range result.Threads {
+		resp.Threads[i] = toProtoThreadWithNicknames(thread, nicknames)
+	}
+	if result.NextCursor != nil {
+		token, err := store.EncodeOrganizationThreadPageToken(organizationID, filter, sortSpec, *result.NextCursor)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "encode page token: %v", err)
+		}
+		resp.NextPageToken = token
+	}
+	return resp, nil
+}
+
 func (s *Server) GetOrganizationThreads(ctx context.Context, req *threadsv1.GetOrganizationThreadsRequest) (*threadsv1.GetOrganizationThreadsResponse, error) {
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
@@ -400,20 +463,28 @@ func (s *Server) GetOrganizationThreads(ctx context.Context, req *threadsv1.GetO
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "status: %v", err)
 	}
+	filter := store.OrganizationThreadFilter{}
+	if statusFilter != nil {
+		filter.StatusIn = []store.ThreadStatus{*statusFilter}
+	}
+	sortSpec := store.OrganizationThreadSort{Field: store.OrganizationThreadSortFieldCreated, Direction: store.SortDirectionDesc}
 
 	var cursor *store.OrganizationThreadCursor
 	if token := req.GetPageToken(); token != "" {
-		tokenOrgID, tokenCursor, err := store.DecodeOrganizationThreadPageToken(token)
+		tokenOrgID, tokenFilter, tokenSort, tokenCursor, err := store.DecodeOrganizationThreadPageToken(token)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 		}
 		if tokenOrgID != organizationID {
 			return nil, status.Error(codes.InvalidArgument, "page_token does not match organization")
 		}
+		if !organizationThreadFilterEqual(tokenFilter, filter) || !organizationThreadSortEqual(tokenSort, sortSpec) {
+			return nil, status.Error(codes.InvalidArgument, "page_token does not match request")
+		}
 		cursor = &tokenCursor
 	}
 
-	result, err := s.store.ListOrganizationThreads(ctx, organizationID, statusFilter, req.GetPageSize(), cursor)
+	result, err := s.store.ListOrganizationThreads(ctx, organizationID, filter, sortSpec, req.GetPageSize(), cursor)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -422,7 +493,7 @@ func (s *Server) GetOrganizationThreads(ctx context.Context, req *threadsv1.GetO
 		resp.Threads[i] = toProtoThread(thread)
 	}
 	if result.NextCursor != nil {
-		token, err := store.EncodeOrganizationThreadPageToken(organizationID, *result.NextCursor)
+		token, err := store.EncodeOrganizationThreadPageToken(organizationID, filter, sortSpec, *result.NextCursor)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "encode page token: %v", err)
 		}
@@ -837,6 +908,117 @@ func (s *Server) checkCanViewThreads(ctx context.Context, identityID, organizati
 	return s.requireAllowed(ctx, identityID, "can_view_threads", fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()))
 }
 
+func listOrganizationThreadsFilterFromProto(filter *threadsv1.ListOrganizationThreadsFilter) (store.OrganizationThreadFilter, error) {
+	if filter == nil {
+		return store.OrganizationThreadFilter{}, nil
+	}
+
+	result := store.OrganizationThreadFilter{}
+	if len(filter.GetStatusIn()) > 0 {
+		seen := make(map[store.ThreadStatus]struct{}, len(filter.GetStatusIn()))
+		for i, statusValue := range filter.GetStatusIn() {
+			parsed, err := threadStatusFromProto(statusValue)
+			if err != nil {
+				return store.OrganizationThreadFilter{}, status.Errorf(codes.InvalidArgument, "filter.status_in[%d]: %v", i, err)
+			}
+			if _, ok := seen[parsed]; ok {
+				continue
+			}
+			seen[parsed] = struct{}{}
+			result.StatusIn = append(result.StatusIn, parsed)
+		}
+		sort.Slice(result.StatusIn, func(i, j int) bool { return result.StatusIn[i] < result.StatusIn[j] })
+	}
+
+	if len(filter.GetParticipantIdIn()) > 0 {
+		seen := make(map[uuid.UUID]struct{}, len(filter.GetParticipantIdIn()))
+		for i, raw := range filter.GetParticipantIdIn() {
+			participantID, err := parseUUID(strings.TrimSpace(raw))
+			if err != nil {
+				return store.OrganizationThreadFilter{}, status.Errorf(codes.InvalidArgument, "filter.participant_id_in[%d]: %v", i, err)
+			}
+			if _, ok := seen[participantID]; ok {
+				continue
+			}
+			seen[participantID] = struct{}{}
+			result.ParticipantIDs = append(result.ParticipantIDs, participantID)
+		}
+		sort.Slice(result.ParticipantIDs, func(i, j int) bool { return result.ParticipantIDs[i].String() < result.ParticipantIDs[j].String() })
+	}
+
+	if filter.GetCreatedAfter() != nil {
+		if err := filter.GetCreatedAfter().CheckValid(); err != nil {
+			return store.OrganizationThreadFilter{}, status.Errorf(codes.InvalidArgument, "filter.created_after: %v", err)
+		}
+		value := filter.GetCreatedAfter().AsTime().UTC()
+		result.CreatedAfter = &value
+	}
+	if filter.GetCreatedBefore() != nil {
+		if err := filter.GetCreatedBefore().CheckValid(); err != nil {
+			return store.OrganizationThreadFilter{}, status.Errorf(codes.InvalidArgument, "filter.created_before: %v", err)
+		}
+		value := filter.GetCreatedBefore().AsTime().UTC()
+		result.CreatedBefore = &value
+	}
+
+	return result, nil
+}
+
+func listOrganizationThreadsSortFromProto(sortSpec *threadsv1.ListOrganizationThreadsSort) (store.OrganizationThreadSort, error) {
+	field := threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_CREATED
+	direction := threadsv1.SortDirection_SORT_DIRECTION_DESC
+	if sortSpec != nil {
+		if sortSpec.GetField() != threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_UNSPECIFIED {
+			field = sortSpec.GetField()
+		}
+		if sortSpec.GetDirection() != threadsv1.SortDirection_SORT_DIRECTION_UNSPECIFIED {
+			direction = sortSpec.GetDirection()
+		}
+	}
+
+	var storeField store.OrganizationThreadSortField
+	switch field {
+	case threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_CREATED:
+		storeField = store.OrganizationThreadSortFieldCreated
+	case threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_UPDATED:
+		storeField = store.OrganizationThreadSortFieldUpdated
+	case threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_MESSAGE_COUNT:
+		storeField = store.OrganizationThreadSortFieldMessageCount
+	case threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_STATUS:
+		storeField = store.OrganizationThreadSortFieldStatus
+	default:
+		return store.OrganizationThreadSort{}, status.Error(codes.InvalidArgument, "sort.field: invalid sort field")
+	}
+
+	var storeDirection store.SortDirection
+	switch direction {
+	case threadsv1.SortDirection_SORT_DIRECTION_ASC:
+		storeDirection = store.SortDirectionAsc
+	case threadsv1.SortDirection_SORT_DIRECTION_DESC:
+		storeDirection = store.SortDirectionDesc
+	default:
+		return store.OrganizationThreadSort{}, status.Error(codes.InvalidArgument, "sort.direction: invalid sort direction")
+	}
+
+	return store.OrganizationThreadSort{
+		Field:     storeField,
+		Direction: storeDirection,
+	}, nil
+}
+
+func threadStatusFromProto(status threadsv1.ThreadStatus) (store.ThreadStatus, error) {
+	switch status {
+	case threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE:
+		return store.ThreadStatusActive, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_ARCHIVED:
+		return store.ThreadStatusArchived, nil
+	case threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED:
+		return store.ThreadStatusDegraded, nil
+	default:
+		return store.ThreadStatusUnspecified, errors.New("invalid thread status")
+	}
+}
+
 func threadStatusFilterFromProto(status threadsv1.ThreadStatus) (*store.ThreadStatus, error) {
 	switch status {
 	case threadsv1.ThreadStatus_THREAD_STATUS_UNSPECIFIED:
@@ -864,6 +1046,84 @@ func messageOrderFromProto(order threadsv1.MessageOrder) (store.MessageOrder, er
 	default:
 		return store.MessageOrderOldestFirst, errors.New("invalid message order")
 	}
+}
+
+func organizationThreadFilterEqual(left, right store.OrganizationThreadFilter) bool {
+	if len(left.StatusIn) != len(right.StatusIn) {
+		return false
+	}
+	for i := range left.StatusIn {
+		if left.StatusIn[i] != right.StatusIn[i] {
+			return false
+		}
+	}
+	if len(left.ParticipantIDs) != len(right.ParticipantIDs) {
+		return false
+	}
+	for i := range left.ParticipantIDs {
+		if left.ParticipantIDs[i] != right.ParticipantIDs[i] {
+			return false
+		}
+	}
+	if (left.CreatedAfter == nil) != (right.CreatedAfter == nil) {
+		return false
+	}
+	if left.CreatedAfter != nil && !left.CreatedAfter.Equal(*right.CreatedAfter) {
+		return false
+	}
+	if (left.CreatedBefore == nil) != (right.CreatedBefore == nil) {
+		return false
+	}
+	if left.CreatedBefore != nil && !left.CreatedBefore.Equal(*right.CreatedBefore) {
+		return false
+	}
+	return true
+}
+
+func organizationThreadSortEqual(left, right store.OrganizationThreadSort) bool {
+	return left.Field == right.Field && left.Direction == right.Direction
+}
+
+func (s *Server) batchResolveNicknames(ctx context.Context, organizationID uuid.UUID, threads []store.Thread) (map[uuid.UUID]string, error) {
+	if s.identity == nil {
+		return nil, status.Error(codes.Internal, "identity service not configured")
+	}
+	participantIDs := make(map[uuid.UUID]struct{})
+	for _, thread := range threads {
+		for _, participant := range thread.Participants {
+			participantIDs[participant.ID] = struct{}{}
+		}
+	}
+	if len(participantIDs) == 0 {
+		return map[uuid.UUID]string{}, nil
+	}
+
+	identityIDs := make([]string, 0, len(participantIDs))
+	for id := range participantIDs {
+		identityIDs = append(identityIDs, id.String())
+	}
+	sort.Strings(identityIDs)
+
+	response, err := s.identity.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: organizationID.String(),
+		IdentityIds:    identityIDs,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "batch get nicknames: %v", err)
+	}
+
+	nicknames := make(map[uuid.UUID]string, len(response.GetEntries()))
+	for i, entry := range response.GetEntries() {
+		if entry == nil {
+			return nil, status.Errorf(codes.Internal, "nickname entry[%d]: missing", i)
+		}
+		identityID, err := parseUUID(entry.GetIdentityId())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "nickname entry[%d].identity_id: %v", i, err)
+		}
+		nicknames[identityID] = entry.GetNickname()
+	}
+	return nicknames, nil
 }
 
 type initiatorInfo struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/threads/internal/store"
 )
@@ -26,7 +29,7 @@ type stubThreadStore struct {
 	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
 	sendMessageFn    func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
 	getThreadFn      func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	listOrgThreadsFn func(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	listOrgThreadsFn func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
 	listMessagesFn   func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
 	listUnackedFn    func(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
 	ackMessagesFn    func(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
@@ -90,12 +93,12 @@ func (s *stubThreadStore) ListThreads(context.Context, uuid.UUID, int32, *store.
 	return store.ThreadListResult{}, nil
 }
 
-func (s *stubThreadStore) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+func (s *stubThreadStore) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
 	s.t.Helper()
 	if s.listOrgThreadsFn == nil {
 		s.t.Fatalf("unexpected ListOrganizationThreads call")
 	}
-	return s.listOrgThreadsFn(ctx, organizationID, status, pageSize, cursor)
+	return s.listOrgThreadsFn(ctx, organizationID, filter, sort, pageSize, cursor)
 }
 
 func (s *stubThreadStore) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error) {
@@ -125,6 +128,7 @@ func (s *stubThreadStore) AckMessages(ctx context.Context, participantID uuid.UU
 type stubIdentityResolver struct {
 	t         *testing.T
 	resolveFn func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error)
+	batchFn   func(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error)
 }
 
 func (s *stubIdentityResolver) ResolveNickname(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
@@ -133,6 +137,14 @@ func (s *stubIdentityResolver) ResolveNickname(ctx context.Context, req *identit
 		s.t.Fatalf("unexpected ResolveNickname call")
 	}
 	return s.resolveFn(ctx, req, opts...)
+}
+
+func (s *stubIdentityResolver) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+	s.t.Helper()
+	if s.batchFn == nil {
+		s.t.Fatalf("unexpected BatchGetNicknames call")
+	}
+	return s.batchFn(ctx, req, opts...)
 }
 
 type stubAgentsService struct {
@@ -1812,12 +1824,14 @@ func TestGetOrganizationThreadsPagination(t *testing.T) {
 	createdAt := time.Now().UTC().Add(-2 * time.Hour)
 	updatedAt := createdAt.Add(10 * time.Minute)
 	pageCursor := store.OrganizationThreadCursor{CreatedAt: createdAt.Add(30 * time.Minute), ThreadID: uuid.New()}
-	pageToken, err := store.EncodeOrganizationThreadPageToken(organizationID, pageCursor)
+	filter := store.OrganizationThreadFilter{}
+	sortSpec := store.OrganizationThreadSort{Field: store.OrganizationThreadSortFieldCreated, Direction: store.SortDirectionDesc}
+	pageToken, err := store.EncodeOrganizationThreadPageToken(organizationID, filter, sortSpec, pageCursor)
 	if err != nil {
 		t.Fatalf("encode page token: %v", err)
 	}
 	nextCursor := store.OrganizationThreadCursor{CreatedAt: createdAt, ThreadID: threadID}
-	expectedNextToken, err := store.EncodeOrganizationThreadPageToken(organizationID, nextCursor)
+	expectedNextToken, err := store.EncodeOrganizationThreadPageToken(organizationID, filter, sortSpec, nextCursor)
 	if err != nil {
 		t.Fatalf("encode next token: %v", err)
 	}
@@ -1826,13 +1840,16 @@ func TestGetOrganizationThreadsPagination(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, listFilter store.OrganizationThreadFilter, listSort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
 			storeCalled = true
 			if orgID != organizationID {
 				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
 			}
-			if status != nil {
-				t.Fatalf("expected nil status filter")
+			if !organizationThreadFiltersEqual(listFilter, filter) {
+				t.Fatalf("unexpected filter: %+v", listFilter)
+			}
+			if listSort != sortSpec {
+				t.Fatalf("unexpected sort: %+v", listSort)
 			}
 			if pageSize != 1 {
 				t.Fatalf("expected page size 1, got %d", pageSize)
@@ -1903,13 +1920,17 @@ func TestGetOrganizationThreadsDegradedStatusFilter(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, status *store.ThreadStatus, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, filter store.OrganizationThreadFilter, sortSpec store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
 			storeCalled = true
 			if orgID != organizationID {
 				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
 			}
-			if status == nil || *status != store.ThreadStatusDegraded {
-				t.Fatalf("expected degraded status filter, got %v", status)
+			if len(filter.StatusIn) != 1 || filter.StatusIn[0] != store.ThreadStatusDegraded {
+				t.Fatalf("expected degraded status filter, got %+v", filter.StatusIn)
+			}
+			expectedSort := store.OrganizationThreadSort{Field: store.OrganizationThreadSortFieldCreated, Direction: store.SortDirectionDesc}
+			if sortSpec != expectedSort {
+				t.Fatalf("unexpected sort: %+v", sortSpec)
 			}
 			return store.OrganizationThreadListResult{}, nil
 		},
@@ -1924,6 +1945,227 @@ func TestGetOrganizationThreadsDegradedStatusFilter(t *testing.T) {
 	}
 	if !storeCalled {
 		t.Fatal("expected GetOrganizationThreads to be called")
+	}
+}
+
+func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authCalled := false
+
+	authStub := &stubAuthorizationService{
+		t: t,
+		checkFn: func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+			authCalled = true
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	srv := New(&stubThreadStore{t: t}, nil, authStub, nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{OrganizationId: organizationID.String()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %s: %s", st.Code(), st.Message())
+	}
+	if !authCalled {
+		t.Fatal("expected authorization check")
+	}
+}
+
+func TestListOrganizationThreadsFilterSortPagination(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	participantA := uuid.New()
+	participantB := uuid.New()
+	createdAfter := time.Now().UTC().Add(-24 * time.Hour)
+	createdBefore := time.Now().UTC().Add(-2 * time.Hour)
+	updatedAt := time.Now().UTC().Add(-1 * time.Hour)
+	threadID := uuid.New()
+	pageCursor := store.OrganizationThreadCursor{UpdatedAt: updatedAt.Add(-5 * time.Minute), ThreadID: uuid.New()}
+
+	filter := &threadsv1.ListOrganizationThreadsFilter{
+		StatusIn:        []threadsv1.ThreadStatus{threadsv1.ThreadStatus_THREAD_STATUS_DEGRADED, threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE},
+		ParticipantIdIn: []string{participantB.String(), " " + participantA.String() + " "},
+		CreatedAfter:    timestamppb.New(createdAfter),
+		CreatedBefore:   timestamppb.New(createdBefore),
+	}
+	sortSpec := &threadsv1.ListOrganizationThreadsSort{
+		Field:     threadsv1.ListOrganizationThreadsSortField_LIST_ORGANIZATION_THREADS_SORT_FIELD_UPDATED,
+		Direction: threadsv1.SortDirection_SORT_DIRECTION_ASC,
+	}
+	expectedStatuses := []store.ThreadStatus{store.ThreadStatusActive, store.ThreadStatusDegraded}
+	sort.Slice(expectedStatuses, func(i, j int) bool { return expectedStatuses[i] < expectedStatuses[j] })
+	expectedParticipants := []uuid.UUID{participantA, participantB}
+	sort.Slice(expectedParticipants, func(i, j int) bool { return expectedParticipants[i].String() < expectedParticipants[j].String() })
+	expectedFilter := store.OrganizationThreadFilter{
+		StatusIn:       expectedStatuses,
+		ParticipantIDs: expectedParticipants,
+		CreatedAfter:   &createdAfter,
+		CreatedBefore:  &createdBefore,
+	}
+	expectedSort := store.OrganizationThreadSort{Field: store.OrganizationThreadSortFieldUpdated, Direction: store.SortDirectionAsc}
+	pageToken, err := store.EncodeOrganizationThreadPageToken(organizationID, expectedFilter, expectedSort, pageCursor)
+	if err != nil {
+		t.Fatalf("encode page token: %v", err)
+	}
+	nextCursor := store.OrganizationThreadCursor{UpdatedAt: updatedAt, ThreadID: threadID}
+	expectedNextToken, err := store.EncodeOrganizationThreadPageToken(organizationID, expectedFilter, expectedSort, nextCursor)
+	if err != nil {
+		t.Fatalf("encode next page token: %v", err)
+	}
+
+	storeCalled := false
+	identityCalled := false
+
+	storeStub := &stubThreadStore{
+		t: t,
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, listFilter store.OrganizationThreadFilter, listSort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+			storeCalled = true
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
+			if !organizationThreadFiltersEqual(listFilter, expectedFilter) {
+				t.Fatalf("unexpected filter: %+v", listFilter)
+			}
+			if listSort != expectedSort {
+				t.Fatalf("unexpected sort: %+v", listSort)
+			}
+			if pageSize != 2 {
+				t.Fatalf("expected page size 2, got %d", pageSize)
+			}
+			if cursor == nil {
+				t.Fatal("expected cursor")
+			}
+			if cursor.ThreadID != pageCursor.ThreadID || !cursor.UpdatedAt.Equal(pageCursor.UpdatedAt) {
+				t.Fatalf("unexpected cursor: %+v", cursor)
+			}
+			return store.OrganizationThreadListResult{
+				Threads: []store.Thread{
+					{
+						ID:             threadID,
+						OrganizationID: &organizationID,
+						MessageCount:   1,
+						Status:         store.ThreadStatusActive,
+						CreatedAt:      createdAfter.Add(2 * time.Hour),
+						UpdatedAt:      updatedAt,
+						Participants: []store.Participant{
+							{ID: participantA, JoinedAt: createdAfter, Passive: false},
+							{ID: participantB, JoinedAt: createdAfter, Passive: true},
+						},
+					},
+				},
+				NextCursor: &nextCursor,
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		batchFn: func(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+			identityCalled = true
+			if req.GetOrganizationId() != organizationID.String() {
+				t.Fatalf("expected organization id %s, got %s", organizationID, req.GetOrganizationId())
+			}
+			expectedIDs := []string{participantA.String(), participantB.String()}
+			sort.Strings(expectedIDs)
+			if !reflect.DeepEqual(req.GetIdentityIds(), expectedIDs) {
+				t.Fatalf("expected identity ids %v, got %v", expectedIDs, req.GetIdentityIds())
+			}
+			return &identityv1.BatchGetNicknamesResponse{}, nil
+		},
+	}
+	authStub := allowAuthStub(t)
+
+	srv := New(storeStub, nil, authStub, identityStub, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	resp, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{
+		OrganizationId: organizationID.String(),
+		Filter:         filter,
+		Sort:           sortSpec,
+		PageSize:       2,
+		PageToken:      pageToken,
+	})
+	if err != nil {
+		t.Fatalf("ListOrganizationThreads returned error: %v", err)
+	}
+	if !storeCalled {
+		t.Fatal("expected ListOrganizationThreads to be called")
+	}
+	if !identityCalled {
+		t.Fatal("expected BatchGetNicknames to be called")
+	}
+	if resp.GetNextPageToken() != expectedNextToken {
+		t.Fatalf("expected next page token %s, got %s", expectedNextToken, resp.GetNextPageToken())
+	}
+}
+
+func TestListOrganizationThreadsNicknameEnrichment(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	threadID := uuid.New()
+	participantA := uuid.New()
+	participantB := uuid.New()
+	createdAt := time.Now().UTC().Add(-2 * time.Hour)
+
+	storeStub := &stubThreadStore{
+		t: t,
+		listOrgThreadsFn: func(ctx context.Context, orgID uuid.UUID, filter store.OrganizationThreadFilter, sortSpec store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error) {
+			return store.OrganizationThreadListResult{
+				Threads: []store.Thread{
+					{
+						ID:             threadID,
+						OrganizationID: &organizationID,
+						MessageCount:   2,
+						Status:         store.ThreadStatusActive,
+						CreatedAt:      createdAt,
+						UpdatedAt:      createdAt,
+						Participants: []store.Participant{
+							{ID: participantA, JoinedAt: createdAt, Passive: false},
+							{ID: participantB, JoinedAt: createdAt, Passive: false},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		batchFn: func(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+			return &identityv1.BatchGetNicknamesResponse{
+				Entries: []*identityv1.NicknameEntry{
+					{IdentityId: participantA.String(), Nickname: "alpha"},
+				},
+			}, nil
+		},
+	}
+	authStub := allowAuthStub(t)
+
+	srv := New(storeStub, nil, authStub, identityStub, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	resp, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{OrganizationId: organizationID.String()})
+	if err != nil {
+		t.Fatalf("ListOrganizationThreads returned error: %v", err)
+	}
+	if len(resp.GetThreads()) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(resp.GetThreads()))
+	}
+	thread := resp.GetThreads()[0]
+	participantOne := findProtoParticipant(thread, participantA)
+	if participantOne == nil || participantOne.GetNickname() != "alpha" {
+		t.Fatalf("expected nickname alpha for participantA, got %+v", participantOne)
+	}
+	participantTwo := findProtoParticipant(thread, participantB)
+	if participantTwo == nil {
+		t.Fatal("expected participantB")
+	}
+	if participantTwo.GetNickname() != "" {
+		t.Fatalf("expected empty nickname for participantB, got %s", participantTwo.GetNickname())
 	}
 }
 
@@ -2190,4 +2432,36 @@ func findProtoParticipant(thread *threadsv1.Thread, id uuid.UUID) *threadsv1.Par
 		}
 	}
 	return nil
+}
+
+func organizationThreadFiltersEqual(left, right store.OrganizationThreadFilter) bool {
+	if len(left.StatusIn) != len(right.StatusIn) {
+		return false
+	}
+	for i := range left.StatusIn {
+		if left.StatusIn[i] != right.StatusIn[i] {
+			return false
+		}
+	}
+	if len(left.ParticipantIDs) != len(right.ParticipantIDs) {
+		return false
+	}
+	for i := range left.ParticipantIDs {
+		if left.ParticipantIDs[i] != right.ParticipantIDs[i] {
+			return false
+		}
+	}
+	if (left.CreatedAfter == nil) != (right.CreatedAfter == nil) {
+		return false
+	}
+	if left.CreatedAfter != nil && !left.CreatedAfter.Equal(*right.CreatedAfter) {
+		return false
+	}
+	if (left.CreatedBefore == nil) != (right.CreatedBefore == nil) {
+		return false
+	}
+	if left.CreatedBefore != nil && !left.CreatedBefore.Equal(*right.CreatedBefore) {
+		return false
+	}
+	return true
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -454,6 +454,7 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 	threadID := uuid.New()
 	organizationID := uuid.New()
 	participantID := uuid.New()
+	identityID := uuid.New()
 	now := time.Now().UTC()
 	storeCalled := false
 	identityCalled := false
@@ -488,6 +489,19 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 		t: t,
 		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
 			identityCalled = true
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				t.Fatal("expected outgoing metadata")
+			}
+			if value := md.Get(identityIDMetadataKey); len(value) != 1 || value[0] != identityID.String() {
+				t.Fatalf("expected %s %s, got %v", identityIDMetadataKey, identityID, value)
+			}
+			if value := md.Get(identityTypeMetadataKey); len(value) != 0 {
+				t.Fatalf("expected no %s metadata, got %v", identityTypeMetadataKey, value)
+			}
+			if value := md.Get(organizationIDMetadataKey); len(value) != 1 || value[0] != organizationID.String() {
+				t.Fatalf("expected %s %s, got %v", organizationIDMetadataKey, organizationID, value)
+			}
 			if req.GetOrganizationId() != organizationID.String() {
 				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
 			}
@@ -498,11 +512,13 @@ func TestCreateThreadNicknameUsesOrganizationID(t *testing.T) {
 		},
 	}
 
-	identityID := uuid.New()
 	authStub := allowAuthStub(t)
 	srv := New(storeStub, nil, authStub, identityStub, nil, nil)
 	orgIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", identityID.String(), "x-organization-id", organizationID.String()),
+	)
 	resp, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{
 		OrganizationId: &orgIDValue,
 		Participants: []*threadsv1.ParticipantIdentifier{
@@ -1982,6 +1998,7 @@ func TestListOrganizationThreadsAuthorizationDenied(t *testing.T) {
 func TestListOrganizationThreadsFilterSortPagination(t *testing.T) {
 	organizationID := uuid.New()
 	identityID := uuid.New()
+	identityType := "user"
 	participantA := uuid.New()
 	participantB := uuid.New()
 	createdAfter := time.Now().UTC().Add(-24 * time.Hour)
@@ -2069,6 +2086,19 @@ func TestListOrganizationThreadsFilterSortPagination(t *testing.T) {
 		t: t,
 		batchFn: func(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
 			identityCalled = true
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				t.Fatal("expected outgoing metadata")
+			}
+			if value := md.Get(identityIDMetadataKey); len(value) != 1 || value[0] != identityID.String() {
+				t.Fatalf("expected %s %s, got %v", identityIDMetadataKey, identityID, value)
+			}
+			if value := md.Get(identityTypeMetadataKey); len(value) != 1 || value[0] != identityType {
+				t.Fatalf("expected %s %s, got %v", identityTypeMetadataKey, identityType, value)
+			}
+			if value := md.Get(organizationIDMetadataKey); len(value) != 1 || value[0] != organizationID.String() {
+				t.Fatalf("expected %s %s, got %v", organizationIDMetadataKey, organizationID, value)
+			}
 			if req.GetOrganizationId() != organizationID.String() {
 				t.Fatalf("expected organization id %s, got %s", organizationID, req.GetOrganizationId())
 			}
@@ -2083,7 +2113,10 @@ func TestListOrganizationThreadsFilterSortPagination(t *testing.T) {
 	authStub := allowAuthStub(t)
 
 	srv := New(storeStub, nil, authStub, identityStub, nil, nil)
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("x-identity-id", identityID.String(), "x-identity-type", identityType, "x-organization-id", organizationID.String()),
+	)
 	resp, err := srv.ListOrganizationThreads(ctx, &threadsv1.ListOrganizationThreadsRequest{
 		OrganizationId: organizationID.String(),
 		Filter:         filter,

--- a/internal/store/pagination.go
+++ b/internal/store/pagination.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -71,16 +72,60 @@ func DecodeThreadPageToken(token string) (uuid.UUID, ThreadCursor, error) {
 }
 
 type organizationThreadPageToken struct {
-	OrganizationID string `json:"organization_id"`
-	CreatedAtNanos int64  `json:"created_at_nanos"`
-	ThreadID       string `json:"thread_id"`
+	OrganizationID     string   `json:"organization_id"`
+	SortField          int      `json:"sort_field,omitempty"`
+	SortDirection      int      `json:"sort_direction,omitempty"`
+	StatusIn           []int16  `json:"status_in,omitempty"`
+	ParticipantIDIn    []string `json:"participant_id_in,omitempty"`
+	CreatedAfterNanos  *int64   `json:"created_after_nanos,omitempty"`
+	CreatedBeforeNanos *int64   `json:"created_before_nanos,omitempty"`
+	CreatedAtNanos     *int64   `json:"created_at_nanos,omitempty"`
+	UpdatedAtNanos     *int64   `json:"updated_at_nanos,omitempty"`
+	MessageCount       *int32   `json:"message_count,omitempty"`
+	Status             *int16   `json:"status,omitempty"`
+	ThreadID           string   `json:"thread_id"`
 }
 
-func EncodeOrganizationThreadPageToken(organizationID uuid.UUID, cursor OrganizationThreadCursor) (string, error) {
+func EncodeOrganizationThreadPageToken(organizationID uuid.UUID, filter OrganizationThreadFilter, sort OrganizationThreadSort, cursor OrganizationThreadCursor) (string, error) {
 	payload := organizationThreadPageToken{
 		OrganizationID: organizationID.String(),
-		CreatedAtNanos: cursor.CreatedAt.UnixNano(),
+		SortField:      int(sort.Field),
+		SortDirection:  int(sort.Direction),
 		ThreadID:       cursor.ThreadID.String(),
+	}
+	if len(filter.StatusIn) > 0 {
+		statusValues := make([]int16, len(filter.StatusIn))
+		for i, status := range filter.StatusIn {
+			statusValues[i] = int16(status)
+		}
+		payload.StatusIn = statusValues
+	}
+	if len(filter.ParticipantIDs) > 0 {
+		payload.ParticipantIDIn = uuidsToStrings(filter.ParticipantIDs)
+	}
+	if filter.CreatedAfter != nil {
+		createdAfter := filter.CreatedAfter.UnixNano()
+		payload.CreatedAfterNanos = &createdAfter
+	}
+	if filter.CreatedBefore != nil {
+		createdBefore := filter.CreatedBefore.UnixNano()
+		payload.CreatedBeforeNanos = &createdBefore
+	}
+	switch sort.Field {
+	case OrganizationThreadSortFieldCreated:
+		createdAt := cursor.CreatedAt.UnixNano()
+		payload.CreatedAtNanos = &createdAt
+	case OrganizationThreadSortFieldUpdated:
+		updatedAt := cursor.UpdatedAt.UnixNano()
+		payload.UpdatedAtNanos = &updatedAt
+	case OrganizationThreadSortFieldMessageCount:
+		messageCount := cursor.MessageCount
+		payload.MessageCount = &messageCount
+	case OrganizationThreadSortFieldStatus:
+		status := int16(cursor.Status)
+		payload.Status = &status
+	default:
+		return "", fmt.Errorf("unsupported sort field: %d", sort.Field)
 	}
 	buf, err := json.Marshal(payload)
 	if err != nil {
@@ -89,30 +134,122 @@ func EncodeOrganizationThreadPageToken(organizationID uuid.UUID, cursor Organiza
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
-func DecodeOrganizationThreadPageToken(token string) (uuid.UUID, OrganizationThreadCursor, error) {
+func DecodeOrganizationThreadPageToken(token string) (uuid.UUID, OrganizationThreadFilter, OrganizationThreadSort, OrganizationThreadCursor, error) {
 	if token == "" {
-		return uuid.UUID{}, OrganizationThreadCursor{}, errors.New("empty token")
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, errors.New("empty token")
 	}
 	data, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
-		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("decode token: %w", err)
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("decode token: %w", err)
 	}
 	var payload organizationThreadPageToken
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("unmarshal token: %w", err)
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("unmarshal token: %w", err)
 	}
 	organizationID, err := uuid.Parse(payload.OrganizationID)
 	if err != nil {
-		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("parse organization id: %w", err)
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("parse organization id: %w", err)
 	}
+	sortField := OrganizationThreadSortField(payload.SortField)
+	if sortField == OrganizationThreadSortFieldUnspecified {
+		sortField = OrganizationThreadSortFieldCreated
+	}
+	if err := validateOrganizationThreadSortField(sortField); err != nil {
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, err
+	}
+	sortDirection := SortDirection(payload.SortDirection)
+	if sortDirection == SortDirectionUnspecified {
+		sortDirection = SortDirectionDesc
+	}
+	if err := validateSortDirection(sortDirection); err != nil {
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, err
+	}
+
+	filter := OrganizationThreadFilter{}
+	if len(payload.StatusIn) > 0 {
+		statusValues := make([]ThreadStatus, 0, len(payload.StatusIn))
+		for _, raw := range payload.StatusIn {
+			status, err := ParseThreadStatus(raw)
+			if err != nil {
+				return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("parse status filter: %w", err)
+			}
+			statusValues = append(statusValues, status)
+		}
+		sort.Slice(statusValues, func(i, j int) bool { return statusValues[i] < statusValues[j] })
+		filter.StatusIn = statusValues
+	}
+	if len(payload.ParticipantIDIn) > 0 {
+		participantIDs := make([]uuid.UUID, 0, len(payload.ParticipantIDIn))
+		for _, raw := range payload.ParticipantIDIn {
+			participantID, err := uuid.Parse(raw)
+			if err != nil {
+				return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("parse participant id: %w", err)
+			}
+			participantIDs = append(participantIDs, participantID)
+		}
+		sort.Slice(participantIDs, func(i, j int) bool { return participantIDs[i].String() < participantIDs[j].String() })
+		filter.ParticipantIDs = participantIDs
+	}
+	if payload.CreatedAfterNanos != nil {
+		createdAfter := time.Unix(0, *payload.CreatedAfterNanos).UTC()
+		filter.CreatedAfter = &createdAfter
+	}
+	if payload.CreatedBeforeNanos != nil {
+		createdBefore := time.Unix(0, *payload.CreatedBeforeNanos).UTC()
+		filter.CreatedBefore = &createdBefore
+	}
+
 	threadID, err := uuid.Parse(payload.ThreadID)
 	if err != nil {
-		return uuid.UUID{}, OrganizationThreadCursor{}, fmt.Errorf("parse thread id: %w", err)
+		return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("parse thread id: %w", err)
 	}
-	return organizationID, OrganizationThreadCursor{
-		CreatedAt: time.Unix(0, payload.CreatedAtNanos).UTC(),
-		ThreadID:  threadID,
-	}, nil
+	cursor := OrganizationThreadCursor{ThreadID: threadID}
+	switch sortField {
+	case OrganizationThreadSortFieldCreated:
+		if payload.CreatedAtNanos == nil {
+			return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, errors.New("missing created_at cursor")
+		}
+		cursor.CreatedAt = time.Unix(0, *payload.CreatedAtNanos).UTC()
+	case OrganizationThreadSortFieldUpdated:
+		if payload.UpdatedAtNanos == nil {
+			return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, errors.New("missing updated_at cursor")
+		}
+		cursor.UpdatedAt = time.Unix(0, *payload.UpdatedAtNanos).UTC()
+	case OrganizationThreadSortFieldMessageCount:
+		if payload.MessageCount == nil {
+			return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, errors.New("missing message_count cursor")
+		}
+		cursor.MessageCount = *payload.MessageCount
+	case OrganizationThreadSortFieldStatus:
+		if payload.Status == nil {
+			return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, errors.New("missing status cursor")
+		}
+		status, err := ParseThreadStatus(*payload.Status)
+		if err != nil {
+			return uuid.UUID{}, OrganizationThreadFilter{}, OrganizationThreadSort{}, OrganizationThreadCursor{}, fmt.Errorf("parse status cursor: %w", err)
+		}
+		cursor.Status = status
+	}
+
+	return organizationID, filter, OrganizationThreadSort{Field: sortField, Direction: sortDirection}, cursor, nil
+}
+
+func validateOrganizationThreadSortField(field OrganizationThreadSortField) error {
+	switch field {
+	case OrganizationThreadSortFieldCreated, OrganizationThreadSortFieldUpdated, OrganizationThreadSortFieldMessageCount, OrganizationThreadSortFieldStatus:
+		return nil
+	default:
+		return fmt.Errorf("invalid sort field: %d", field)
+	}
+}
+
+func validateSortDirection(direction SortDirection) error {
+	switch direction {
+	case SortDirectionAsc, SortDirectionDesc:
+		return nil
+	default:
+		return fmt.Errorf("invalid sort direction: %d", direction)
+	}
 }
 
 type messagePageToken struct {

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func (s *Store) CreateThread(ctx context.Context, organizationID uuid.UUID, participantInputs []ParticipantInput) (Thread, error) {
@@ -194,28 +195,14 @@ func (s *Store) ListThreads(ctx context.Context, participantID uuid.UUID, pageSi
 	return ThreadListResult{Threads: threads, NextCursor: nextCursor}, nil
 }
 
-func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, status *ThreadStatus, pageSize int32, cursor *OrganizationThreadCursor) (OrganizationThreadListResult, error) {
+func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, filter OrganizationThreadFilter, sort OrganizationThreadSort, pageSize int32, cursor *OrganizationThreadCursor) (OrganizationThreadListResult, error) {
 	limit := normalizePageSize(pageSize)
-	query := strings.Builder{}
-	query.WriteString(`SELECT id, status, created_at, updated_at, organization_id, message_count
-        FROM threads
-        WHERE organization_id = $1`)
-	args := []any{organizationID}
-	paramIndex := 2
-	if status != nil {
-		query.WriteString(fmt.Sprintf(" AND status = $%d", paramIndex))
-		args = append(args, int16(*status))
-		paramIndex++
+	query, args, err := buildOrganizationThreadsQuery(organizationID, filter, sort, cursor, limit)
+	if err != nil {
+		return OrganizationThreadListResult{}, err
 	}
-	if cursor != nil {
-		query.WriteString(fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", paramIndex, paramIndex+1))
-		args = append(args, cursor.CreatedAt, cursor.ThreadID)
-		paramIndex += 2
-	}
-	query.WriteString(fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", paramIndex))
-	args = append(args, int(limit)+1)
 
-	rows, err := s.pool.Query(ctx, query.String(), args...)
+	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return OrganizationThreadListResult{}, err
 	}
@@ -224,8 +211,7 @@ func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid
 	threads := make([]Thread, 0, limit)
 	var (
 		nextCursor *OrganizationThreadCursor
-		lastID     uuid.UUID
-		lastTime   time.Time
+		lastThread Thread
 		hasMore    bool
 	)
 	for rows.Next() {
@@ -238,14 +224,17 @@ func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid
 			break
 		}
 		threads = append(threads, thread)
-		lastID = thread.ID
-		lastTime = thread.CreatedAt
+		lastThread = thread
 	}
 	if err := rows.Err(); err != nil {
 		return OrganizationThreadListResult{}, err
 	}
 	if hasMore {
-		nextCursor = &OrganizationThreadCursor{CreatedAt: lastTime, ThreadID: lastID}
+		nextCursorValue, err := organizationThreadCursorFromThread(lastThread, sort.Field)
+		if err != nil {
+			return OrganizationThreadListResult{}, err
+		}
+		nextCursor = &nextCursorValue
 	}
 
 	for i := range threads {
@@ -257,6 +246,118 @@ func (s *Store) ListOrganizationThreads(ctx context.Context, organizationID uuid
 	}
 
 	return OrganizationThreadListResult{Threads: threads, NextCursor: nextCursor}, nil
+}
+
+func buildOrganizationThreadsQuery(organizationID uuid.UUID, filter OrganizationThreadFilter, sort OrganizationThreadSort, cursor *OrganizationThreadCursor, limit int32) (string, []any, error) {
+	sortColumn, err := organizationThreadSortColumn(sort.Field)
+	if err != nil {
+		return "", nil, err
+	}
+	orderDirection, cursorOperator, err := organizationThreadSortDirection(sort.Direction)
+	if err != nil {
+		return "", nil, err
+	}
+
+	query := strings.Builder{}
+	query.WriteString(`SELECT t.id, t.status, t.created_at, t.updated_at, t.organization_id, t.message_count
+        FROM threads t
+        WHERE t.organization_id = $1`)
+	args := []any{organizationID}
+	paramIndex := 2
+	if len(filter.StatusIn) > 0 {
+		statusValues := make([]int16, len(filter.StatusIn))
+		for i, status := range filter.StatusIn {
+			statusValues[i] = int16(status)
+		}
+		query.WriteString(fmt.Sprintf(" AND t.status = ANY($%d)", paramIndex))
+		args = append(args, pgtype.FlatArray[int16](statusValues))
+		paramIndex++
+	}
+	if len(filter.ParticipantIDs) > 0 {
+		query.WriteString(fmt.Sprintf(" AND EXISTS (SELECT 1 FROM thread_participants tp WHERE tp.thread_id = t.id AND tp.participant_id = ANY($%d))", paramIndex))
+		args = append(args, pgtype.FlatArray[uuid.UUID](filter.ParticipantIDs))
+		paramIndex++
+	}
+	if filter.CreatedAfter != nil {
+		query.WriteString(fmt.Sprintf(" AND t.created_at >= $%d", paramIndex))
+		args = append(args, *filter.CreatedAfter)
+		paramIndex++
+	}
+	if filter.CreatedBefore != nil {
+		query.WriteString(fmt.Sprintf(" AND t.created_at < $%d", paramIndex))
+		args = append(args, *filter.CreatedBefore)
+		paramIndex++
+	}
+	if cursor != nil {
+		cursorValue, err := organizationThreadCursorValue(sort.Field, *cursor)
+		if err != nil {
+			return "", nil, err
+		}
+		query.WriteString(fmt.Sprintf(" AND (%s %s $%d OR (%s = $%d AND t.id > $%d))", sortColumn, cursorOperator, paramIndex, sortColumn, paramIndex, paramIndex+1))
+		args = append(args, cursorValue, cursor.ThreadID)
+		paramIndex += 2
+	}
+	query.WriteString(fmt.Sprintf(" ORDER BY %s %s, t.id ASC LIMIT $%d", sortColumn, orderDirection, paramIndex))
+	args = append(args, int(limit)+1)
+	return query.String(), args, nil
+}
+
+func organizationThreadSortColumn(field OrganizationThreadSortField) (string, error) {
+	switch field {
+	case OrganizationThreadSortFieldCreated:
+		return "t.created_at", nil
+	case OrganizationThreadSortFieldUpdated:
+		return "t.updated_at", nil
+	case OrganizationThreadSortFieldMessageCount:
+		return "t.message_count", nil
+	case OrganizationThreadSortFieldStatus:
+		return "t.status", nil
+	default:
+		return "", fmt.Errorf("unsupported sort field: %d", field)
+	}
+}
+
+func organizationThreadSortDirection(direction SortDirection) (string, string, error) {
+	switch direction {
+	case SortDirectionAsc:
+		return "ASC", ">", nil
+	case SortDirectionDesc:
+		return "DESC", "<", nil
+	default:
+		return "", "", fmt.Errorf("unsupported sort direction: %d", direction)
+	}
+}
+
+func organizationThreadCursorValue(field OrganizationThreadSortField, cursor OrganizationThreadCursor) (any, error) {
+	switch field {
+	case OrganizationThreadSortFieldCreated:
+		return cursor.CreatedAt, nil
+	case OrganizationThreadSortFieldUpdated:
+		return cursor.UpdatedAt, nil
+	case OrganizationThreadSortFieldMessageCount:
+		return cursor.MessageCount, nil
+	case OrganizationThreadSortFieldStatus:
+		return int16(cursor.Status), nil
+	default:
+		return nil, fmt.Errorf("unsupported sort field: %d", field)
+	}
+}
+
+func organizationThreadCursorFromThread(thread Thread, field OrganizationThreadSortField) (OrganizationThreadCursor, error) {
+	cursor := OrganizationThreadCursor{ThreadID: thread.ID}
+	switch field {
+	case OrganizationThreadSortFieldCreated:
+		cursor.CreatedAt = thread.CreatedAt
+	case OrganizationThreadSortFieldUpdated:
+		cursor.UpdatedAt = thread.UpdatedAt
+	case OrganizationThreadSortFieldMessageCount:
+		cursor.MessageCount = thread.MessageCount
+	case OrganizationThreadSortFieldStatus:
+		cursor.Status = thread.Status
+	default:
+		return OrganizationThreadCursor{}, fmt.Errorf("unsupported sort field: %d", field)
+	}
+	return cursor, nil
 }
 
 func (s *Store) GetThread(ctx context.Context, threadID uuid.UUID) (Thread, error) {

--- a/internal/store/threads_list_test.go
+++ b/internal/store/threads_list_test.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestBuildOrganizationThreadsQueryFilters(t *testing.T) {
+	organizationID := uuid.New()
+	participantA := uuid.New()
+	participantB := uuid.New()
+	createdAfter := time.Now().UTC().Add(-48 * time.Hour)
+	createdBefore := time.Now().UTC().Add(-24 * time.Hour)
+
+	filter := OrganizationThreadFilter{
+		StatusIn:       []ThreadStatus{ThreadStatusArchived, ThreadStatusActive},
+		ParticipantIDs: []uuid.UUID{participantA, participantB},
+		CreatedAfter:   &createdAfter,
+		CreatedBefore:  &createdBefore,
+	}
+	sort := OrganizationThreadSort{Field: OrganizationThreadSortFieldCreated, Direction: SortDirectionDesc}
+
+	query, args, err := buildOrganizationThreadsQuery(organizationID, filter, sort, nil, 5)
+	if err != nil {
+		t.Fatalf("build query: %v", err)
+	}
+	if !strings.Contains(query, "t.status = ANY($2)") {
+		t.Fatalf("expected status filter, got %s", query)
+	}
+	if !strings.Contains(query, "tp.participant_id = ANY($3)") {
+		t.Fatalf("expected participant filter, got %s", query)
+	}
+	if !strings.Contains(query, "t.created_at >= $4") {
+		t.Fatalf("expected created_after filter, got %s", query)
+	}
+	if !strings.Contains(query, "t.created_at < $5") {
+		t.Fatalf("expected created_before filter, got %s", query)
+	}
+	if !strings.Contains(query, "ORDER BY t.created_at DESC, t.id ASC") {
+		t.Fatalf("expected deterministic order, got %s", query)
+	}
+	if len(args) != 6 {
+		t.Fatalf("expected 6 args, got %d", len(args))
+	}
+	if args[0] != organizationID {
+		t.Fatalf("expected organization arg %s, got %v", organizationID, args[0])
+	}
+	statusArg, ok := args[1].(pgtype.FlatArray[int16])
+	if !ok {
+		t.Fatalf("expected status array arg, got %T", args[1])
+	}
+	if !reflect.DeepEqual([]int16(statusArg), []int16{int16(ThreadStatusArchived), int16(ThreadStatusActive)}) {
+		t.Fatalf("unexpected status args %v", statusArg)
+	}
+	participantArg, ok := args[2].(pgtype.FlatArray[uuid.UUID])
+	if !ok {
+		t.Fatalf("expected participant array arg, got %T", args[2])
+	}
+	if !reflect.DeepEqual([]uuid.UUID(participantArg), []uuid.UUID{participantA, participantB}) {
+		t.Fatalf("unexpected participant args %v", participantArg)
+	}
+	if args[3] != createdAfter {
+		t.Fatalf("expected created_after arg %v, got %v", createdAfter, args[3])
+	}
+	if args[4] != createdBefore {
+		t.Fatalf("expected created_before arg %v, got %v", createdBefore, args[4])
+	}
+	if args[5] != 6 {
+		t.Fatalf("expected limit arg 6, got %v", args[5])
+	}
+}
+
+func TestBuildOrganizationThreadsQueryCreatedAscCursor(t *testing.T) {
+	organizationID := uuid.New()
+	cursor := OrganizationThreadCursor{CreatedAt: time.Now().UTC(), ThreadID: uuid.New()}
+	sort := OrganizationThreadSort{Field: OrganizationThreadSortFieldCreated, Direction: SortDirectionAsc}
+
+	query, args, err := buildOrganizationThreadsQuery(organizationID, OrganizationThreadFilter{}, sort, &cursor, 3)
+	if err != nil {
+		t.Fatalf("build query: %v", err)
+	}
+	if !strings.Contains(query, "AND (t.created_at > $2 OR (t.created_at = $2 AND t.id > $3))") {
+		t.Fatalf("expected cursor filter, got %s", query)
+	}
+	if !strings.Contains(query, "ORDER BY t.created_at ASC, t.id ASC") {
+		t.Fatalf("expected asc order, got %s", query)
+	}
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args, got %d", len(args))
+	}
+	if args[1] != cursor.CreatedAt {
+		t.Fatalf("expected cursor time arg %v, got %v", cursor.CreatedAt, args[1])
+	}
+	if args[2] != cursor.ThreadID {
+		t.Fatalf("expected cursor id arg %s, got %v", cursor.ThreadID, args[2])
+	}
+	if args[3] != 4 {
+		t.Fatalf("expected limit arg 4, got %v", args[3])
+	}
+}
+
+func TestBuildOrganizationThreadsQueryStatusDescCursor(t *testing.T) {
+	organizationID := uuid.New()
+	cursor := OrganizationThreadCursor{Status: ThreadStatusArchived, ThreadID: uuid.New()}
+	sort := OrganizationThreadSort{Field: OrganizationThreadSortFieldStatus, Direction: SortDirectionDesc}
+
+	query, args, err := buildOrganizationThreadsQuery(organizationID, OrganizationThreadFilter{}, sort, &cursor, 2)
+	if err != nil {
+		t.Fatalf("build query: %v", err)
+	}
+	if !strings.Contains(query, "AND (t.status < $2 OR (t.status = $2 AND t.id > $3))") {
+		t.Fatalf("expected cursor filter, got %s", query)
+	}
+	if !strings.Contains(query, "ORDER BY t.status DESC, t.id ASC") {
+		t.Fatalf("expected desc order, got %s", query)
+	}
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args, got %d", len(args))
+	}
+	if args[1] != int16(ThreadStatusArchived) {
+		t.Fatalf("expected status arg %v, got %v", ThreadStatusArchived, args[1])
+	}
+	if args[2] != cursor.ThreadID {
+		t.Fatalf("expected cursor id arg %s, got %v", cursor.ThreadID, args[2])
+	}
+	if args[3] != 3 {
+		t.Fatalf("expected limit arg 3, got %v", args[3])
+	}
+}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -69,14 +69,47 @@ const (
 	MessageOrderNewestFirst
 )
 
+type SortDirection int
+
+const (
+	SortDirectionUnspecified SortDirection = iota
+	SortDirectionAsc
+	SortDirectionDesc
+)
+
+type OrganizationThreadSortField int
+
+const (
+	OrganizationThreadSortFieldUnspecified OrganizationThreadSortField = iota
+	OrganizationThreadSortFieldCreated
+	OrganizationThreadSortFieldUpdated
+	OrganizationThreadSortFieldMessageCount
+	OrganizationThreadSortFieldStatus
+)
+
+type OrganizationThreadSort struct {
+	Field     OrganizationThreadSortField
+	Direction SortDirection
+}
+
+type OrganizationThreadFilter struct {
+	StatusIn       []ThreadStatus
+	ParticipantIDs []uuid.UUID
+	CreatedAfter   *time.Time
+	CreatedBefore  *time.Time
+}
+
 type ThreadCursor struct {
 	UpdatedAt time.Time
 	ThreadID  uuid.UUID
 }
 
 type OrganizationThreadCursor struct {
-	CreatedAt time.Time
-	ThreadID  uuid.UUID
+	ThreadID     uuid.UUID
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	MessageCount int32
+	Status       ThreadStatus
 }
 
 type MessageCursor struct {


### PR DESCRIPTION
## Summary
- implement ListOrganizationThreads filter/sort pagination with deterministic cursors
- add nickname enrichment via Identity batch lookup
- extend store query building and tests plus devspace buf paths

## Testing
- buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
- go vet ./...
- go test ./...
- go build ./...

Refs #27