### PR TITLE
fix(chart): set numeric security user

### DIFF
--- a/charts/threads/values.yaml
+++ b/charts/threads/values.yaml
@@ -39,6 +39,8 @@ podSecurityContext:
 
 securityContext:
   enabled: true
+  runAsUser: 100
+  runAsGroup: 101
   runAsNonRoot: true
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Adds numeric default `runAsUser: 100` and `runAsGroup: 101` alongside `runAsNonRoot: true` in the chart security context.
- Leaves umbrella/provisioning unchanged; this is chart-owned.

Fixes #38

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1`
- `go test ./...` — 3 passed, 0 failed, 0 skipped
- `helm dependency build charts/threads`
- `helm lint charts/threads` — 1 chart linted, 0 failed
- `helm template threads charts/threads` — rendered `runAsNonRoot: true`, `runAsUser: 100`, and `runAsGroup: 101`
- `gofmt -w $(git ls-files '*.go')`
- `git diff --check`

## Release note
Chart release/version bump should happen after merge only.
