### PR TITLE
feat: route thread agents through instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
           go-version: '1.24.x'
 
       - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 1.66.0
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.66.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Generate protobuf bindings
         run: buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1

--- a/cmd/threads/main.go
+++ b/cmd/threads/main.go
@@ -90,14 +90,18 @@ func run() error {
 	threadsServer := grpc.NewServer()
 	threadsv1.RegisterThreadsServiceServer(
 		threadsServer,
-		server.New(
-			store.NewStore(pool),
-			notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
-			authorizationv1.NewAuthorizationServiceClient(authorizationConn),
-			identityv1.NewIdentityServiceClient(identityConn),
-			agentsv1.NewAgentsServiceClient(agentsConn),
-			metering.New(meteringv1.NewMeteringServiceClient(meteringConn)),
-		),
+		func() *server.Server {
+			threadsService := server.New(
+				store.NewStore(pool),
+				notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn)),
+				authorizationv1.NewAuthorizationServiceClient(authorizationConn),
+				identityv1.NewIdentityServiceClient(identityConn),
+				agentsv1.NewAgentsServiceClient(agentsConn),
+				metering.New(meteringv1.NewMeteringServiceClient(meteringConn)),
+			)
+			threadsService.StartAgentInboxDeliveryWorker(ctx)
+			return threadsService
+		}(),
 	)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,15 +33,17 @@ type Server struct {
 }
 
 const (
-	organizationIDMetadataKey = "x-organization-id"
-	identityIDMetadataKey     = "x-identity-id"
-	identityTypeMetadataKey   = "x-identity-type"
-	agentIdentityType         = "agent"
-	agentInstanceIdentityType = "agent_instance"
-	meteringTimeout           = 5 * time.Second
-	identityObjectPrefix      = "identity:"
-	organizationObjectPrefix  = "organization:"
-	threadObjectPrefix        = "thread:"
+	organizationIDMetadataKey  = "x-organization-id"
+	identityIDMetadataKey      = "x-identity-id"
+	identityTypeMetadataKey    = "x-identity-type"
+	agentIdentityType          = "agent"
+	agentInstanceIdentityType  = "agent_instance"
+	meteringTimeout            = 5 * time.Second
+	agentInboxDeliveryInterval = 5 * time.Second
+	agentInboxDeliveryLimit    = 100
+	identityObjectPrefix       = "identity:"
+	organizationObjectPrefix   = "organization:"
+	threadObjectPrefix         = "thread:"
 )
 
 type threadStore interface {
@@ -49,7 +51,7 @@ type threadStore interface {
 	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	DegradeThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
-	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
+	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
 	GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *store.ThreadCursor) (store.ThreadListResult, error)
 	ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
@@ -57,6 +59,9 @@ type threadStore interface {
 	ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
 	GetUnackedMessageCounts(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
 	AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
+	ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
+	MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error
+	MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error
 }
 
 type identityResolver interface {
@@ -302,11 +307,17 @@ func (s *Server) identityTypes(ctx context.Context, ids []uuid.UUID) (map[uuid.U
 		if _, ok := requestedIDs[identityID]; !ok {
 			return nil, status.Errorf(codes.Internal, "identity type entry[%d].identity_id: unexpected identity", i)
 		}
+		if _, ok := typesByID[identityID]; ok {
+			return nil, status.Errorf(codes.Internal, "identity type entry[%d].identity_id: duplicate identity", i)
+		}
 		typesByID[identityID] = entry.GetIdentityType()
+	}
+	if len(response.GetEntries()) != len(ids) {
+		return nil, status.Errorf(codes.Internal, "batch get identity types: expected %d entries, got %d", len(ids), len(response.GetEntries()))
 	}
 	for _, id := range ids {
 		if _, ok := typesByID[id]; !ok {
-			typesByID[id] = identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED
+			return nil, status.Errorf(codes.Internal, "batch get identity types: missing identity %s", id.String())
 		}
 	}
 	return typesByID, nil
@@ -514,13 +525,13 @@ func (s *Server) SendMessage(ctx context.Context, req *threadsv1.SendMessageRequ
 	if err != nil {
 		return nil, err
 	}
-	result, err := s.store.SendMessage(ctx, threadID, senderID, req.GetBody(), fileIDs, messageRecipients)
+	result, err := s.store.SendMessage(ctx, threadID, senderID, req.GetBody(), fileIDs, messageRecipients, agentInstanceRecipients)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
 	s.recordMessageSent(ctx, result)
-	if err := s.fanoutInboxItems(ctx, agentInstanceRecipients, result.Message); err != nil {
-		return nil, err
+	if err := s.deliverAgentInboxDeliveries(ctx, result.AgentInboxDeliveries); err != nil {
+		log.Printf("agent inbox delivery: %v", err)
 	}
 	if err := s.notifier.PublishMessageCreated(ctx, threadID, result.Message.ID, result.Recipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "notify recipients: %v", err)
@@ -563,31 +574,70 @@ func (s *Server) deliveryRecipients(ctx context.Context, participants []store.Pa
 	return messageRecipients, agentInstanceRecipients, nil
 }
 
-func (s *Server) fanoutInboxItems(ctx context.Context, agentInstanceIDs []uuid.UUID, message store.Message) error {
-	if len(agentInstanceIDs) == 0 {
-		return nil
-	}
-	if s.agents == nil {
-		return status.Error(codes.Internal, "agents service not configured")
-	}
-	fileIDs := make([]string, len(message.FileIDs))
-	for i, fileID := range message.FileIDs {
-		fileIDs[i] = fileID.String()
-	}
-	for _, agentInstanceID := range agentInstanceIDs {
-		_, err := s.agents.FanoutInboxItem(ctx, &agentsv1.FanoutInboxItemRequest{
-			AgentInstanceId: agentInstanceID.String(),
-			ThreadId:        message.ThreadID.String(),
-			MessageId:       message.ID.String(),
-			SenderId:        message.SenderID.String(),
-			Body:            message.Body,
-			FileIds:         fileIDs,
-		})
-		if err != nil {
-			return status.Errorf(codes.Internal, "fanout inbox item: %v", err)
+func (s *Server) deliverAgentInboxDeliveries(ctx context.Context, deliveries []store.AgentInboxDelivery) error {
+	for _, delivery := range deliveries {
+		if err := s.deliverAgentInboxDelivery(ctx, delivery); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (s *Server) deliverAgentInboxDelivery(ctx context.Context, delivery store.AgentInboxDelivery) error {
+	if s.agents == nil {
+		return status.Error(codes.Internal, "agents service not configured")
+	}
+	fileIDs := make([]string, len(delivery.FileIDs))
+	for i, fileID := range delivery.FileIDs {
+		fileIDs[i] = fileID.String()
+	}
+	_, err := s.agents.FanoutInboxItem(ctx, &agentsv1.FanoutInboxItemRequest{
+		AgentInstanceId: delivery.AgentInstanceID.String(),
+		ThreadId:        delivery.ThreadID.String(),
+		MessageId:       delivery.MessageID.String(),
+		SenderId:        delivery.SenderID.String(),
+		Body:            delivery.Body,
+		FileIds:         fileIDs,
+	})
+	if err != nil {
+		message := fmt.Sprintf("fanout inbox item: %v", err)
+		if markErr := s.store.MarkAgentInboxDeliveryFailed(ctx, delivery.MessageID, delivery.AgentInstanceID, message); markErr != nil {
+			return status.Errorf(codes.Internal, "%s; mark failed: %v", message, markErr)
+		}
+		return status.Error(codes.Internal, message)
+	}
+	if err := s.store.MarkAgentInboxDeliveryDelivered(ctx, delivery.MessageID, delivery.AgentInstanceID); err != nil {
+		return status.Errorf(codes.Internal, "mark agent inbox delivery delivered: %v", err)
+	}
+	return nil
+}
+
+func (s *Server) DrainPendingAgentInboxDeliveries(ctx context.Context) error {
+	deliveries, err := s.store.ListPendingAgentInboxDeliveries(ctx, agentInboxDeliveryLimit)
+	if err != nil {
+		return status.Errorf(codes.Internal, "list pending agent inbox deliveries: %v", err)
+	}
+	return s.deliverAgentInboxDeliveries(ctx, deliveries)
+}
+
+func (s *Server) StartAgentInboxDeliveryWorker(ctx context.Context) {
+	go func() {
+		if err := s.DrainPendingAgentInboxDeliveries(ctx); err != nil {
+			log.Printf("agent inbox delivery drain: %v", err)
+		}
+		ticker := time.NewTicker(agentInboxDeliveryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.DrainPendingAgentInboxDeliveries(ctx); err != nil {
+					log.Printf("agent inbox delivery drain: %v", err)
+				}
+			}
+		}
+	}()
 }
 
 func (s *Server) GetThreads(ctx context.Context, req *threadsv1.GetThreadsRequest) (*threadsv1.GetThreadsResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ const (
 	identityIDMetadataKey     = "x-identity-id"
 	identityTypeMetadataKey   = "x-identity-type"
 	agentIdentityType         = "agent"
+	agentInstanceIdentityType = "agent_instance"
 	meteringTimeout           = 5 * time.Second
 	identityObjectPrefix      = "identity:"
 	organizationObjectPrefix  = "organization:"
@@ -48,7 +49,7 @@ type threadStore interface {
 	ArchiveThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	DegradeThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	AddParticipant(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
-	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
+	SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
 	GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	ListThreads(ctx context.Context, participantID uuid.UUID, pageSize int32, cursor *store.ThreadCursor) (store.ThreadListResult, error)
 	ListOrganizationThreads(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
@@ -66,6 +67,9 @@ type identityResolver interface {
 
 type agentsService interface {
 	GetAgent(ctx context.Context, in *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	CreateInstance(ctx context.Context, in *agentsv1.CreateInstanceRequest, opts ...grpc.CallOption) (*agentsv1.CreateInstanceResponse, error)
+	GetInstance(ctx context.Context, in *agentsv1.GetInstanceRequest, opts ...grpc.CallOption) (*agentsv1.GetInstanceResponse, error)
+	FanoutInboxItem(ctx context.Context, in *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error)
 }
 
 type authorizationChecker interface {
@@ -172,10 +176,15 @@ func (s *Server) CreateThread(ctx context.Context, req *threadsv1.CreateThreadRe
 	}
 	participants := make([]store.ParticipantInput, 0, capacity)
 	if hasInitiator {
-		participants = append(participants, store.ParticipantInput{ID: initiator.ID, Passive: initiator.Passive})
+		participants = append(participants, store.ParticipantInput{ID: initiator.ID, Passive: false})
 	}
 	participants = append(participants, resolved...)
-	if err := s.requireCanInitiateAgentParticipants(ctx, identityID, participants); err != nil {
+	finalParticipants, agentClassIDs, err := s.finalizeParticipants(ctx, participants, initiator.ID, hasInitiator)
+	if err != nil {
+		return nil, err
+	}
+	participants = finalParticipants
+	if err := s.requireCanInitiateAgentClasses(ctx, identityID, agentClassIDs); err != nil {
 		return nil, err
 	}
 
@@ -219,12 +228,8 @@ func addResolvedParticipant(id uuid.UUID, initiator initiatorInfo, hasInitiator 
 	return nil
 }
 
-func (s *Server) requireCanInitiateAgentParticipants(ctx context.Context, callerID uuid.UUID, participants []store.ParticipantInput) error {
-	agentIDs, err := s.agentParticipantIDs(ctx, participants)
-	if err != nil {
-		return err
-	}
-	for _, agentID := range agentIDs {
+func (s *Server) requireCanInitiateAgentClasses(ctx context.Context, callerID uuid.UUID, agentClassIDs []uuid.UUID) error {
+	for _, agentID := range agentClassIDs {
 		if err := s.requireAllowed(ctx, callerID, "can_initiate", fmt.Sprintf("agent:%s", agentID.String())); err != nil {
 			return err
 		}
@@ -232,18 +237,50 @@ func (s *Server) requireCanInitiateAgentParticipants(ctx context.Context, caller
 	return nil
 }
 
-func (s *Server) agentParticipantIDs(ctx context.Context, participants []store.ParticipantInput) ([]uuid.UUID, error) {
+func (s *Server) finalizeParticipants(ctx context.Context, participants []store.ParticipantInput, initiatorID uuid.UUID, hasInitiator bool) ([]store.ParticipantInput, []uuid.UUID, error) {
 	if len(participants) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
+	ids := make([]uuid.UUID, len(participants))
+	for i, participant := range participants {
+		ids[i] = participant.ID
+	}
+	typesByID, err := s.identityTypes(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	finalParticipants := make([]store.ParticipantInput, 0, len(participants))
+	seen := make(map[uuid.UUID]struct{}, len(participants))
+	agentClassIDs := make([]uuid.UUID, 0)
+	for i, participant := range participants {
+		storedID, agentClassID, err := s.finalParticipantID(ctx, participant.ID, typesByID[participant.ID])
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, ok := seen[storedID]; ok {
+			if hasInitiator && storedID == initiatorID {
+				continue
+			}
+			return nil, nil, status.Errorf(codes.InvalidArgument, "participants[%d]: duplicate participant", i)
+		}
+		seen[storedID] = struct{}{}
+		finalParticipants = append(finalParticipants, store.ParticipantInput{ID: storedID, Passive: false})
+		if agentClassID != uuid.Nil {
+			agentClassIDs = append(agentClassIDs, agentClassID)
+		}
+	}
+	return finalParticipants, agentClassIDs, nil
+}
+
+func (s *Server) identityTypes(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]identityv1.IdentityType, error) {
 	if s.identity == nil {
 		return nil, status.Error(codes.Internal, "identity service not configured")
 	}
-	identityIDs := make([]string, len(participants))
-	participantIDs := make(map[uuid.UUID]struct{}, len(participants))
-	for i, participant := range participants {
-		identityIDs[i] = participant.ID.String()
-		participantIDs[participant.ID] = struct{}{}
+	identityIDs := make([]string, len(ids))
+	requestedIDs := make(map[uuid.UUID]struct{}, len(ids))
+	for i, id := range ids {
+		identityIDs[i] = id.String()
+		requestedIDs[id] = struct{}{}
 	}
 	identityCtx, err := identityClientContext(ctx)
 	if err != nil {
@@ -253,24 +290,88 @@ func (s *Server) agentParticipantIDs(ctx context.Context, participants []store.P
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "batch get identity types: %v", err)
 	}
-	agentIDs := make([]uuid.UUID, 0)
+	typesByID := make(map[uuid.UUID]identityv1.IdentityType, len(ids))
 	for i, entry := range response.GetEntries() {
 		if entry == nil {
 			return nil, status.Errorf(codes.Internal, "identity type entry[%d]: missing", i)
-		}
-		if entry.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_AGENT {
-			continue
 		}
 		identityID, err := parseUUID(entry.GetIdentityId())
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "identity type entry[%d].identity_id: %v", i, err)
 		}
-		if _, ok := participantIDs[identityID]; !ok {
+		if _, ok := requestedIDs[identityID]; !ok {
 			return nil, status.Errorf(codes.Internal, "identity type entry[%d].identity_id: unexpected identity", i)
 		}
-		agentIDs = append(agentIDs, identityID)
+		typesByID[identityID] = entry.GetIdentityType()
 	}
-	return agentIDs, nil
+	for _, id := range ids {
+		if _, ok := typesByID[id]; !ok {
+			typesByID[id] = identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED
+		}
+	}
+	return typesByID, nil
+}
+
+func (s *Server) finalParticipantID(ctx context.Context, id uuid.UUID, identityType identityv1.IdentityType) (uuid.UUID, uuid.UUID, error) {
+	switch identityType {
+	case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
+		instanceID, err := s.createAgentInstance(ctx, id)
+		if err != nil {
+			return uuid.UUID{}, uuid.UUID{}, err
+		}
+		return instanceID, id, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE:
+		classID, err := s.agentClassIDForInstance(ctx, id)
+		if err != nil {
+			return uuid.UUID{}, uuid.UUID{}, err
+		}
+		return id, classID, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED,
+		identityv1.IdentityType_IDENTITY_TYPE_USER,
+		identityv1.IdentityType_IDENTITY_TYPE_APP,
+		identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
+		return id, uuid.Nil, nil
+	default:
+		return uuid.UUID{}, uuid.UUID{}, status.Errorf(codes.InvalidArgument, "unsupported identity type %s", identityType.String())
+	}
+}
+
+func (s *Server) createAgentInstance(ctx context.Context, agentID uuid.UUID) (uuid.UUID, error) {
+	if s.agents == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
+	}
+	response, err := s.agents.CreateInstance(ctx, &agentsv1.CreateInstanceRequest{AgentId: agentID.String()})
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "create agent instance: %v", err)
+	}
+	instance := response.GetInstance()
+	if instance == nil || instance.GetMeta() == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "create agent instance: instance missing")
+	}
+	instanceID, err := parseUUID(instance.GetMeta().GetId())
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "create agent instance id: %v", err)
+	}
+	return instanceID, nil
+}
+
+func (s *Server) agentClassIDForInstance(ctx context.Context, instanceID uuid.UUID) (uuid.UUID, error) {
+	if s.agents == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
+	}
+	response, err := s.agents.GetInstance(ctx, &agentsv1.GetInstanceRequest{Id: instanceID.String()})
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent instance: %v", err)
+	}
+	instance := response.GetInstance()
+	if instance == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "get agent instance: instance missing")
+	}
+	classID, err := parseUUID(instance.GetAgentId())
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent instance agent_id: %v", err)
+	}
+	return classID, nil
 }
 
 func (s *Server) ArchiveThread(ctx context.Context, req *threadsv1.ArchiveThreadRequest) (*threadsv1.ArchiveThreadResponse, error) {
@@ -329,6 +430,9 @@ func (s *Server) DegradeThread(ctx context.Context, req *threadsv1.DegradeThread
 }
 
 func (s *Server) AddParticipant(ctx context.Context, req *threadsv1.AddParticipantRequest) (*threadsv1.AddParticipantResponse, error) {
+	if req.GetPassive() {
+		return nil, status.Error(codes.InvalidArgument, "passive participants are not supported")
+	}
 	threadID, err := parseUUID(req.GetThreadId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "thread_id: %v", err)
@@ -344,10 +448,15 @@ func (s *Server) AddParticipant(ctx context.Context, req *threadsv1.AddParticipa
 	if err != nil {
 		return nil, err
 	}
-	if err := s.requireCanInitiateAgentParticipants(ctx, identityID, []store.ParticipantInput{{ID: participantID}}); err != nil {
+	finalParticipants, agentClassIDs, err := s.finalizeParticipants(ctx, []store.ParticipantInput{{ID: participantID, Passive: false}}, uuid.Nil, false)
+	if err != nil {
 		return nil, err
 	}
-	thread, err := s.store.AddParticipant(ctx, threadID, participantID, req.GetPassive())
+	if err := s.requireCanInitiateAgentClasses(ctx, identityID, agentClassIDs); err != nil {
+		return nil, err
+	}
+	participantID = finalParticipants[0].ID
+	thread, err := s.store.AddParticipant(ctx, threadID, participantID, false)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -397,15 +506,88 @@ func (s *Server) SendMessage(ctx context.Context, req *threadsv1.SendMessageRequ
 		return nil, err
 	}
 
-	result, err := s.store.SendMessage(ctx, threadID, senderID, req.GetBody(), fileIDs)
+	thread, err := s.store.GetThread(ctx, threadID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	messageRecipients, agentInstanceRecipients, err := s.deliveryRecipients(ctx, thread.Participants, senderID)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.store.SendMessage(ctx, threadID, senderID, req.GetBody(), fileIDs, messageRecipients)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
 	s.recordMessageSent(ctx, result)
+	if err := s.fanoutInboxItems(ctx, agentInstanceRecipients, result.Message); err != nil {
+		return nil, err
+	}
 	if err := s.notifier.PublishMessageCreated(ctx, threadID, result.Message.ID, result.Recipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "notify recipients: %v", err)
 	}
 	return &threadsv1.SendMessageResponse{Message: toProtoMessage(result.Message)}, nil
+}
+
+func (s *Server) deliveryRecipients(ctx context.Context, participants []store.Participant, senderID uuid.UUID) ([]uuid.UUID, []uuid.UUID, error) {
+	recipientIDs := make([]uuid.UUID, 0, len(participants))
+	for _, participant := range participants {
+		if participant.ID == senderID {
+			continue
+		}
+		recipientIDs = append(recipientIDs, participant.ID)
+	}
+	if len(recipientIDs) == 0 {
+		return nil, nil, nil
+	}
+	typesByID, err := s.identityTypes(ctx, recipientIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	messageRecipients := make([]uuid.UUID, 0, len(recipientIDs))
+	agentInstanceRecipients := make([]uuid.UUID, 0, len(recipientIDs))
+	for _, recipientID := range recipientIDs {
+		switch typesByID[recipientID] {
+		case identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE:
+			agentInstanceRecipients = append(agentInstanceRecipients, recipientID)
+		case identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED,
+			identityv1.IdentityType_IDENTITY_TYPE_USER,
+			identityv1.IdentityType_IDENTITY_TYPE_APP,
+			identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
+			messageRecipients = append(messageRecipients, recipientID)
+		case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
+			return nil, nil, status.Errorf(codes.FailedPrecondition, "thread contains agent class participant %s", recipientID.String())
+		default:
+			return nil, nil, status.Errorf(codes.FailedPrecondition, "thread contains unsupported participant type %s", typesByID[recipientID].String())
+		}
+	}
+	return messageRecipients, agentInstanceRecipients, nil
+}
+
+func (s *Server) fanoutInboxItems(ctx context.Context, agentInstanceIDs []uuid.UUID, message store.Message) error {
+	if len(agentInstanceIDs) == 0 {
+		return nil
+	}
+	if s.agents == nil {
+		return status.Error(codes.Internal, "agents service not configured")
+	}
+	fileIDs := make([]string, len(message.FileIDs))
+	for i, fileID := range message.FileIDs {
+		fileIDs[i] = fileID.String()
+	}
+	for _, agentInstanceID := range agentInstanceIDs {
+		_, err := s.agents.FanoutInboxItem(ctx, &agentsv1.FanoutInboxItemRequest{
+			AgentInstanceId: agentInstanceID.String(),
+			ThreadId:        message.ThreadID.String(),
+			MessageId:       message.ID.String(),
+			SenderId:        message.SenderID.String(),
+			Body:            message.Body,
+			FileIds:         fileIDs,
+		})
+		if err != nil {
+			return status.Errorf(codes.Internal, "fanout inbox item: %v", err)
+		}
+	}
+	return nil
 }
 
 func (s *Server) GetThreads(ctx context.Context, req *threadsv1.GetThreadsRequest) (*threadsv1.GetThreadsResponse, error) {
@@ -909,13 +1091,27 @@ func (s *Server) organizationIDFromIdentity(ctx context.Context, missingMessage 
 	if identityID == "" || identityType == "" {
 		return uuid.UUID{}, status.Error(codes.InvalidArgument, missingMessage)
 	}
-	if !strings.EqualFold(identityType, agentIdentityType) {
+	agentID := identityID
+	if strings.EqualFold(identityType, agentInstanceIdentityType) {
+		if s.agents == nil {
+			return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
+		}
+		response, err := s.agents.GetInstance(ctx, &agentsv1.GetInstanceRequest{Id: identityID})
+		if err != nil {
+			return uuid.UUID{}, status.Errorf(codes.Internal, "get agent instance: %v", err)
+		}
+		instance := response.GetInstance()
+		if instance == nil {
+			return uuid.UUID{}, status.Error(codes.Internal, "get agent instance: instance missing")
+		}
+		agentID = instance.GetAgentId()
+	} else if !strings.EqualFold(identityType, agentIdentityType) {
 		return uuid.UUID{}, status.Error(codes.InvalidArgument, missingMessage)
 	}
 	if s.agents == nil {
 		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
 	}
-	response, err := s.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: identityID})
+	response, err := s.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {
 		return uuid.UUID{}, status.Errorf(codes.Internal, "get agent: %v", err)
 	}
@@ -956,7 +1152,7 @@ func isAgentIdentity(ctx context.Context) bool {
 		return false
 	}
 	identityType := metadataValue(md, identityTypeMetadataKey)
-	return strings.EqualFold(identityType, agentIdentityType)
+	return strings.EqualFold(identityType, agentIdentityType) || strings.EqualFold(identityType, agentInstanceIdentityType)
 }
 
 func (s *Server) checkAllowed(ctx context.Context, identityID uuid.UUID, relation, object string) (bool, error) {
@@ -1219,7 +1415,11 @@ func (s *Server) batchResolveNicknames(ctx context.Context, organizationID uuid.
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "nickname entry[%d].identity_id: %v", i, err)
 		}
-		nicknames[identityID] = entry.GetNickname()
+		nickname := entry.GetNickname()
+		if suffix := entry.GetInstanceSuffix(); suffix != "" {
+			nickname += "#" + suffix
+		}
+		nicknames[identityID] = nickname
 	}
 	return nicknames, nil
 }
@@ -1243,8 +1443,7 @@ func initiatorInfoFromContext(ctx context.Context) (initiatorInfo, bool, error) 
 	if err != nil {
 		return initiatorInfo{}, false, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-	passive := strings.EqualFold(identityType, agentIdentityType)
-	return initiatorInfo{ID: initiatorID, Passive: passive}, true, nil
+	return initiatorInfo{ID: initiatorID, Passive: false}, true, nil
 }
 
 func metadataValue(md metadata.MD, key string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,9 +59,9 @@ type threadStore interface {
 	ListUnackedMessages(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
 	GetUnackedMessageCounts(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
 	AckMessages(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
-	ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
-	MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error
-	MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error
+	ClaimPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
+	MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID) error
+	MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID, deliveryError string) error
 }
 
 type identityResolver interface {
@@ -530,7 +530,10 @@ func (s *Server) SendMessage(ctx context.Context, req *threadsv1.SendMessageRequ
 		return nil, toStatusError(err)
 	}
 	s.recordMessageSent(ctx, result)
-	if err := s.deliverAgentInboxDeliveries(ctx, result.AgentInboxDeliveries); err != nil {
+	if len(result.AgentInboxDeliveries) > 0 {
+		err = s.DrainPendingAgentInboxDeliveries(ctx)
+	}
+	if err != nil {
 		log.Printf("agent inbox delivery: %v", err)
 	}
 	if err := s.notifier.PublishMessageCreated(ctx, threadID, result.Message.ID, result.Recipients); err != nil {
@@ -575,12 +578,13 @@ func (s *Server) deliveryRecipients(ctx context.Context, participants []store.Pa
 }
 
 func (s *Server) deliverAgentInboxDeliveries(ctx context.Context, deliveries []store.AgentInboxDelivery) error {
+	errs := make([]error, 0)
 	for _, delivery := range deliveries {
 		if err := s.deliverAgentInboxDelivery(ctx, delivery); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (s *Server) deliverAgentInboxDelivery(ctx context.Context, delivery store.AgentInboxDelivery) error {
@@ -601,19 +605,19 @@ func (s *Server) deliverAgentInboxDelivery(ctx context.Context, delivery store.A
 	})
 	if err != nil {
 		message := fmt.Sprintf("fanout inbox item: %v", err)
-		if markErr := s.store.MarkAgentInboxDeliveryFailed(ctx, delivery.MessageID, delivery.AgentInstanceID, message); markErr != nil {
+		if markErr := s.store.MarkAgentInboxDeliveryFailed(ctx, delivery.MessageID, delivery.AgentInstanceID, delivery.ClaimID, message); markErr != nil {
 			return status.Errorf(codes.Internal, "%s; mark failed: %v", message, markErr)
 		}
 		return status.Error(codes.Internal, message)
 	}
-	if err := s.store.MarkAgentInboxDeliveryDelivered(ctx, delivery.MessageID, delivery.AgentInstanceID); err != nil {
+	if err := s.store.MarkAgentInboxDeliveryDelivered(ctx, delivery.MessageID, delivery.AgentInstanceID, delivery.ClaimID); err != nil {
 		return status.Errorf(codes.Internal, "mark agent inbox delivery delivered: %v", err)
 	}
 	return nil
 }
 
 func (s *Server) DrainPendingAgentInboxDeliveries(ctx context.Context) error {
-	deliveries, err := s.store.ListPendingAgentInboxDeliveries(ctx, agentInboxDeliveryLimit)
+	deliveries, err := s.store.ClaimPendingAgentInboxDeliveries(ctx, agentInboxDeliveryLimit)
 	if err != nil {
 		return status.Errorf(codes.Internal, "list pending agent inbox deliveries: %v", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,18 +23,21 @@ import (
 )
 
 type stubThreadStore struct {
-	t                *testing.T
-	createThreadFn   func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
-	archiveThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	degradeThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
-	sendMessageFn    func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
-	getThreadFn      func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	listOrgThreadsFn func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
-	listMessagesFn   func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
-	listUnackedFn    func(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
-	unackedCountsFn  func(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
-	ackMessagesFn    func(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
+	t                                 *testing.T
+	createThreadFn                    func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
+	archiveThreadFn                   func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	degradeThreadFn                   func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	addParticipantFn                  func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
+	sendMessageFn                     func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
+	listPendingAgentInboxDeliveriesFn func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
+	markAgentInboxDeliveryDeliveredFn func(ctx context.Context, messageID, agentInstanceID uuid.UUID) error
+	markAgentInboxDeliveryFailedFn    func(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error
+	getThreadFn                       func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	listOrgThreadsFn                  func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	listMessagesFn                    func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
+	listUnackedFn                     func(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
+	unackedCountsFn                   func(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
+	ackMessagesFn                     func(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
 }
 
 func (s *stubThreadStore) unexpectedCall(method string) {
@@ -74,12 +77,36 @@ func (s *stubThreadStore) AddParticipant(ctx context.Context, threadID, particip
 	return s.addParticipantFn(ctx, threadID, participantID, passive)
 }
 
-func (s *stubThreadStore) SendMessage(ctx context.Context, threadID uuid.UUID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+func (s *stubThreadStore) SendMessage(ctx context.Context, threadID uuid.UUID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 	if s.sendMessageFn == nil {
 		s.unexpectedCall("SendMessage")
 		return store.SendMessageResult{}, nil
 	}
-	return s.sendMessageFn(ctx, threadID, senderID, body, fileIDs, messageRecipientIDs)
+	return s.sendMessageFn(ctx, threadID, senderID, body, fileIDs, messageRecipientIDs, agentInstanceRecipientIDs)
+}
+
+func (s *stubThreadStore) ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+	s.t.Helper()
+	if s.listPendingAgentInboxDeliveriesFn == nil {
+		return nil, nil
+	}
+	return s.listPendingAgentInboxDeliveriesFn(ctx, limit)
+}
+
+func (s *stubThreadStore) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error {
+	s.t.Helper()
+	if s.markAgentInboxDeliveryDeliveredFn == nil {
+		return nil
+	}
+	return s.markAgentInboxDeliveryDeliveredFn(ctx, messageID, agentInstanceID)
+}
+
+func (s *stubThreadStore) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error {
+	s.t.Helper()
+	if s.markAgentInboxDeliveryFailedFn == nil {
+		return nil
+	}
+	return s.markAgentInboxDeliveryFailedFn(ctx, messageID, agentInstanceID, deliveryError)
 }
 
 func (s *stubThreadStore) GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error) {
@@ -1788,7 +1815,7 @@ func TestSendMessageAuthorizationDenied(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			return store.SendMessageResult{}, nil
 		},
@@ -1852,7 +1879,7 @@ func TestSendMessageRecordsUsageWithThreadOrganization(t *testing.T) {
 			}
 			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: identityID, JoinedAt: now, Passive: false}}}, nil
 		},
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			if threadArg != threadID {
 				t.Fatalf("expected thread %s, got %s", threadID, threadArg)
 			}
@@ -1913,7 +1940,7 @@ func TestSendMessageRejectsThreadWithoutOrganization(t *testing.T) {
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
 			return store.Thread{ID: threadID, Participants: []store.Participant{{ID: identityID}}}, nil
 		},
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			return store.SendMessageResult{}, store.ErrThreadOrganizationMissing
 		},
 	}
@@ -1945,7 +1972,7 @@ func TestSendMessageRejectsSenderMismatch(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			return store.SendMessageResult{}, nil
 		},
@@ -1993,7 +2020,7 @@ func TestSendMessageRejectsDegradedThread(t *testing.T) {
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
 			return store.Thread{ID: threadID, Participants: []store.Participant{{ID: identityID}}}, nil
 		},
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			if threadArg != threadID {
 				t.Fatalf("expected thread id %s, got %s", threadID, threadArg)
@@ -2912,11 +2939,14 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
 			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: senderID}, {ID: userRecipientID}, {ID: agentInstanceID}}}, nil
 		},
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			if !reflect.DeepEqual(messageRecipientIDs, []uuid.UUID{userRecipientID}) {
 				t.Fatalf("expected user/app message recipients only, got %v", messageRecipientIDs)
 			}
-			return store.SendMessageResult{Message: store.Message{ID: messageID, ThreadID: threadID, SenderID: senderID, Body: body, FileIDs: fileIDs, CreatedAt: now}, OrganizationID: organizationID, Recipients: messageRecipientIDs}, nil
+			if !reflect.DeepEqual(agentInstanceRecipientIDs, []uuid.UUID{agentInstanceID}) {
+				t.Fatalf("expected agent instance recipients, got %v", agentInstanceRecipientIDs)
+			}
+			return store.SendMessageResult{Message: store.Message{ID: messageID, ThreadID: threadID, SenderID: senderID, Body: body, FileIDs: fileIDs, CreatedAt: now}, OrganizationID: organizationID, Recipients: messageRecipientIDs, AgentInboxDeliveries: []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: body, FileIDs: fileIDs}}}, nil
 		},
 	}
 	identityStub := &stubIdentityResolver{
@@ -2958,5 +2988,72 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 	}
 	if !fanoutCalled {
 		t.Fatal("expected agent instance fanout")
+	}
+}
+
+func TestIdentityTypesRequiresCompleteResponse(t *testing.T) {
+	firstID := uuid.New()
+	secondID := uuid.New()
+	callerID := uuid.New()
+	identityStub := &stubIdentityResolver{
+		t: t,
+		typeBatchFn: func(ctx context.Context, req *identityv1.BatchGetIdentityTypesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetIdentityTypesResponse, error) {
+			return &identityv1.BatchGetIdentityTypesResponse{Entries: []*identityv1.IdentityTypeEntry{{IdentityId: firstID.String(), IdentityType: identityv1.IdentityType_IDENTITY_TYPE_USER}}}, nil
+		},
+	}
+
+	srv := New(&stubThreadStore{t: t}, nil, nil, identityStub, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", callerID.String()))
+	_, err := srv.identityTypes(ctx, []uuid.UUID{firstID, secondID})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got %s: %s", st.Code(), st.Message())
+	}
+}
+
+func TestDrainPendingAgentInboxDeliveriesMarksDelivered(t *testing.T) {
+	messageID := uuid.New()
+	threadID := uuid.New()
+	senderID := uuid.New()
+	agentInstanceID := uuid.New()
+	var marked bool
+	storeStub := &stubThreadStore{
+		t: t,
+		listPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+			if limit != agentInboxDeliveryLimit {
+				t.Fatalf("expected limit %d, got %d", agentInboxDeliveryLimit, limit)
+			}
+			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "hi"}}, nil
+		},
+		markAgentInboxDeliveryDeliveredFn: func(ctx context.Context, messageArg, agentInstanceArg uuid.UUID) error {
+			marked = true
+			if messageArg != messageID || agentInstanceArg != agentInstanceID {
+				t.Fatalf("unexpected delivered mark: %s %s", messageArg, agentInstanceArg)
+			}
+			return nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		fanoutFn: func(ctx context.Context, req *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error) {
+			if req.GetMessageId() != messageID.String() || req.GetAgentInstanceId() != agentInstanceID.String() {
+				t.Fatalf("unexpected fanout request: %+v", req)
+			}
+			return &agentsv1.FanoutInboxItemResponse{}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, agentsStub, nil)
+	if err := srv.DrainPendingAgentInboxDeliveries(context.Background()); err != nil {
+		t.Fatalf("DrainPendingAgentInboxDeliveries returned error: %v", err)
+	}
+	if !marked {
+		t.Fatal("expected delivered mark")
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,7 +28,7 @@ type stubThreadStore struct {
 	archiveThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	degradeThreadFn  func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	addParticipantFn func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
-	sendMessageFn    func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error)
+	sendMessageFn    func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
 	getThreadFn      func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
 	listOrgThreadsFn func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
 	listMessagesFn   func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
@@ -74,12 +74,12 @@ func (s *stubThreadStore) AddParticipant(ctx context.Context, threadID, particip
 	return s.addParticipantFn(ctx, threadID, participantID, passive)
 }
 
-func (s *stubThreadStore) SendMessage(ctx context.Context, threadID uuid.UUID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+func (s *stubThreadStore) SendMessage(ctx context.Context, threadID uuid.UUID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 	if s.sendMessageFn == nil {
 		s.unexpectedCall("SendMessage")
 		return store.SendMessageResult{}, nil
 	}
-	return s.sendMessageFn(ctx, threadID, senderID, body, fileIDs)
+	return s.sendMessageFn(ctx, threadID, senderID, body, fileIDs, messageRecipientIDs)
 }
 
 func (s *stubThreadStore) GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error) {
@@ -171,8 +171,11 @@ func (s *stubIdentityResolver) BatchGetIdentityTypes(ctx context.Context, req *i
 }
 
 type stubAgentsService struct {
-	t          *testing.T
-	getAgentFn func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	t             *testing.T
+	getAgentFn    func(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+	createFn      func(ctx context.Context, req *agentsv1.CreateInstanceRequest, opts ...grpc.CallOption) (*agentsv1.CreateInstanceResponse, error)
+	getInstanceFn func(ctx context.Context, req *agentsv1.GetInstanceRequest, opts ...grpc.CallOption) (*agentsv1.GetInstanceResponse, error)
+	fanoutFn      func(ctx context.Context, req *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error)
 }
 
 func (s *stubAgentsService) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
@@ -181,6 +184,30 @@ func (s *stubAgentsService) GetAgent(ctx context.Context, req *agentsv1.GetAgent
 		s.t.Fatalf("unexpected GetAgent call")
 	}
 	return s.getAgentFn(ctx, req, opts...)
+}
+
+func (s *stubAgentsService) CreateInstance(ctx context.Context, req *agentsv1.CreateInstanceRequest, opts ...grpc.CallOption) (*agentsv1.CreateInstanceResponse, error) {
+	s.t.Helper()
+	if s.createFn == nil {
+		s.t.Fatalf("unexpected CreateInstance call")
+	}
+	return s.createFn(ctx, req, opts...)
+}
+
+func (s *stubAgentsService) GetInstance(ctx context.Context, req *agentsv1.GetInstanceRequest, opts ...grpc.CallOption) (*agentsv1.GetInstanceResponse, error) {
+	s.t.Helper()
+	if s.getInstanceFn == nil {
+		s.t.Fatalf("unexpected GetInstance call")
+	}
+	return s.getInstanceFn(ctx, req, opts...)
+}
+
+func (s *stubAgentsService) FanoutInboxItem(ctx context.Context, req *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error) {
+	s.t.Helper()
+	if s.fanoutFn == nil {
+		s.t.Fatalf("unexpected FanoutInboxItem call")
+	}
+	return s.fanoutFn(ctx, req, opts...)
 }
 
 type stubAuthorizationService struct {
@@ -359,8 +386,8 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 			if participants[0].ID != agentID {
 				t.Fatalf("expected initiator %s first, got %s", agentID, participants[0].ID)
 			}
-			if !participants[0].Passive {
-				t.Fatalf("expected agent passive true")
+			if participants[0].Passive {
+				t.Fatalf("expected agent passive false")
 			}
 			if participants[1].ID != participantID {
 				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
@@ -376,7 +403,7 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				Participants: []store.Participant{
-					{ID: agentID, JoinedAt: now, Passive: true},
+					{ID: agentID, JoinedAt: now, Passive: false},
 					{ID: participantID, JoinedAt: now, Passive: false},
 				},
 			}, nil
@@ -404,8 +431,8 @@ func TestCreateThreadAgentInitiatorPassive(t *testing.T) {
 	if agentParticipant == nil {
 		t.Fatal("expected agent participant in response")
 	}
-	if !agentParticipant.GetPassive() {
-		t.Fatal("expected agent participant passive true")
+	if agentParticipant.GetPassive() {
+		t.Fatal("expected agent participant passive false")
 	}
 }
 
@@ -429,8 +456,8 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 			if participants[0].ID != agentID {
 				t.Fatalf("expected initiator %s, got %s", agentID, participants[0].ID)
 			}
-			if !participants[0].Passive {
-				t.Fatalf("expected initiator passive true")
+			if participants[0].Passive {
+				t.Fatalf("expected initiator passive false")
 			}
 			return store.Thread{
 				ID:             threadID,
@@ -440,7 +467,7 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				Participants: []store.Participant{
-					{ID: agentID, JoinedAt: now, Passive: true},
+					{ID: agentID, JoinedAt: now, Passive: false},
 				},
 			}, nil
 		},
@@ -463,8 +490,8 @@ func TestCreateThreadEmptyParticipantsWithAgentInitiator(t *testing.T) {
 	if agentParticipant == nil {
 		t.Fatal("expected agent participant in response")
 	}
-	if !agentParticipant.GetPassive() {
-		t.Fatal("expected agent participant passive true")
+	if agentParticipant.GetPassive() {
+		t.Fatal("expected agent participant passive false")
 	}
 }
 
@@ -708,8 +735,8 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 			if participants[0].ID != agentID {
 				t.Fatalf("expected initiator %s first, got %s", agentID, participants[0].ID)
 			}
-			if !participants[0].Passive {
-				t.Fatalf("expected initiator passive true")
+			if participants[0].Passive {
+				t.Fatalf("expected initiator passive false")
 			}
 			if participants[1].ID != participantID {
 				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
@@ -722,7 +749,7 @@ func TestCreateThreadNicknameUsesOrganizationIDFromAgentIdentity(t *testing.T) {
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				Participants: []store.Participant{
-					{ID: agentID, JoinedAt: now, Passive: true},
+					{ID: agentID, JoinedAt: now, Passive: false},
 					{ID: participantID, JoinedAt: now, Passive: false},
 				},
 			}, nil
@@ -964,8 +991,8 @@ func assertCreateThreadDedupesInitiator(t *testing.T, initiatorID, participantID
 			if participants[0].ID != initiatorID {
 				t.Fatalf("expected initiator %s first, got %s", initiatorID, participants[0].ID)
 			}
-			if !participants[0].Passive {
-				t.Fatal("expected agent initiator to be passive")
+			if participants[0].Passive {
+				t.Fatal("expected agent initiator to be active")
 			}
 			if participants[1].ID != participantID {
 				t.Fatalf("expected participant %s second, got %s", participantID, participants[1].ID)
@@ -978,7 +1005,7 @@ func assertCreateThreadDedupesInitiator(t *testing.T, initiatorID, participantID
 				CreatedAt:      now,
 				UpdatedAt:      now,
 				Participants: []store.Participant{
-					{ID: initiatorID, JoinedAt: now, Passive: true},
+					{ID: initiatorID, JoinedAt: now, Passive: false},
 					{ID: participantID, JoinedAt: now, Passive: false},
 				},
 			}, nil
@@ -1142,79 +1169,23 @@ func TestCreateThreadWritesAuthorizationTuples(t *testing.T) {
 	}
 }
 
-func TestAddParticipantWithNicknamePassesPassive(t *testing.T) {
+func TestAddParticipantRejectsPassive(t *testing.T) {
 	threadID := uuid.New()
-	organizationID := uuid.New()
 	participantID := uuid.New()
-	now := time.Now().UTC()
-	storeCalled := false
-	identityCalled := false
-
-	storeStub := &stubThreadStore{
-		t: t,
-		addParticipantFn: func(ctx context.Context, threadArg, participantArg uuid.UUID, passive bool) (store.Thread, error) {
-			storeCalled = true
-			if threadArg != threadID {
-				t.Fatalf("expected thread ID %s, got %s", threadID, threadArg)
-			}
-			if participantArg != participantID {
-				t.Fatalf("expected participant ID %s, got %s", participantID, participantArg)
-			}
-			if !passive {
-				t.Fatalf("expected passive true, got %v", passive)
-			}
-			return store.Thread{
-				ID:        threadID,
-				Status:    store.ThreadStatusActive,
-				CreatedAt: now,
-				UpdatedAt: now,
-				Participants: []store.Participant{
-					{ID: participantID, JoinedAt: now, Passive: true},
-				},
-			}, nil
-		},
-	}
-	identityStub := &stubIdentityResolver{
-		t: t,
-		resolveFn: func(ctx context.Context, req *identityv1.ResolveNicknameRequest, opts ...grpc.CallOption) (*identityv1.ResolveNicknameResponse, error) {
-			identityCalled = true
-			if req.GetOrganizationId() != organizationID.String() {
-				t.Fatalf("expected organization ID %s, got %s", organizationID, req.GetOrganizationId())
-			}
-			if req.GetNickname() != "agent-alpha" {
-				t.Fatalf("expected nickname agent-alpha, got %s", req.GetNickname())
-			}
-			return &identityv1.ResolveNicknameResponse{IdentityId: participantID.String()}, nil
-		},
-	}
-
 	identityID := uuid.New()
-	authStub := allowAuthStub(t)
-	srv := New(storeStub, nil, authStub, identityStub, nil, nil)
-	orgIDValue := organizationID.String()
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-organization-id", organizationID.String(), "x-identity-id", identityID.String()))
-	resp, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{
-		ThreadId:       threadID.String(),
-		OrganizationId: &orgIDValue,
-		Passive:        true,
-		Participant: &threadsv1.ParticipantIdentifier{
-			Identifier: &threadsv1.ParticipantIdentifier_ParticipantNickname{ParticipantNickname: "@agent-alpha"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("AddParticipant returned error: %v", err)
+
+	srv := New(&stubThreadStore{t: t}, nil, allowAuthStub(t), nil, nil, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	_, err := srv.AddParticipant(ctx, &threadsv1.AddParticipantRequest{ThreadId: threadID.String(), ParticipantId: participantID.String(), Passive: true})
+	if err == nil {
+		t.Fatal("expected error")
 	}
-	if !storeCalled {
-		t.Fatal("expected AddParticipant to be called")
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
 	}
-	if !identityCalled {
-		t.Fatal("expected ResolveNickname to be called")
-	}
-	if resp.GetThread() == nil || len(resp.GetThread().GetParticipants()) != 1 {
-		t.Fatalf("expected 1 participant, got %v", resp.GetThread().GetParticipants())
-	}
-	if !resp.GetThread().GetParticipants()[0].GetPassive() {
-		t.Fatal("expected passive participant to be true")
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %s", st.Code(), st.Message())
 	}
 }
 
@@ -1817,7 +1788,7 @@ func TestSendMessageAuthorizationDenied(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			return store.SendMessageResult{}, nil
 		},
@@ -1875,7 +1846,13 @@ func TestSendMessageRecordsUsageWithThreadOrganization(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			if id != threadID {
+				t.Fatalf("expected thread %s, got %s", threadID, id)
+			}
+			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: identityID, JoinedAt: now, Passive: false}}}, nil
+		},
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			if threadArg != threadID {
 				t.Fatalf("expected thread %s, got %s", threadID, threadArg)
 			}
@@ -1933,7 +1910,10 @@ func TestSendMessageRejectsThreadWithoutOrganization(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			return store.Thread{ID: threadID, Participants: []store.Participant{{ID: identityID}}}, nil
+		},
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			return store.SendMessageResult{}, store.ErrThreadOrganizationMissing
 		},
 	}
@@ -1965,7 +1945,7 @@ func TestSendMessageRejectsSenderMismatch(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			return store.SendMessageResult{}, nil
 		},
@@ -2010,7 +1990,10 @@ func TestSendMessageRejectsDegradedThread(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
-		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID) (store.SendMessageResult, error) {
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			return store.Thread{ID: threadID, Participants: []store.Participant{{ID: identityID}}}, nil
+		},
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
 			storeCalled = true
 			if threadArg != threadID {
 				t.Fatalf("expected thread id %s, got %s", threadID, threadArg)
@@ -2838,4 +2821,142 @@ func organizationThreadFiltersEqual(left, right store.OrganizationThreadFilter) 
 		return false
 	}
 	return true
+}
+
+func TestCreateThreadStoresAgentInstanceForAgentClassParticipant(t *testing.T) {
+	threadID := uuid.New()
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	agentID := uuid.New()
+	instanceID := uuid.New()
+	now := time.Now().UTC()
+
+	storeStub := &stubThreadStore{
+		t: t,
+		createThreadFn: func(ctx context.Context, orgID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error) {
+			if orgID != organizationID {
+				t.Fatalf("expected organization %s, got %s", organizationID, orgID)
+			}
+			if len(participants) != 2 {
+				t.Fatalf("expected 2 participants, got %d", len(participants))
+			}
+			if participants[1].ID != instanceID {
+				t.Fatalf("expected stored agent instance %s, got %s", instanceID, participants[1].ID)
+			}
+			return store.Thread{
+				ID:             threadID,
+				OrganizationID: &organizationID,
+				Status:         store.ThreadStatusActive,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				Participants: []store.Participant{
+					{ID: identityID, JoinedAt: now},
+					{ID: instanceID, JoinedAt: now},
+				},
+			}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		typeBatchFn: func(ctx context.Context, req *identityv1.BatchGetIdentityTypesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetIdentityTypesResponse, error) {
+			entries := make([]*identityv1.IdentityTypeEntry, len(req.GetIdentityIds()))
+			for i, id := range req.GetIdentityIds() {
+				identityType := identityv1.IdentityType_IDENTITY_TYPE_USER
+				if id == agentID.String() {
+					identityType = identityv1.IdentityType_IDENTITY_TYPE_AGENT
+				}
+				entries[i] = &identityv1.IdentityTypeEntry{IdentityId: id, IdentityType: identityType}
+			}
+			return &identityv1.BatchGetIdentityTypesResponse{Entries: entries}, nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		createFn: func(ctx context.Context, req *agentsv1.CreateInstanceRequest, opts ...grpc.CallOption) (*agentsv1.CreateInstanceResponse, error) {
+			if req.GetAgentId() != agentID.String() {
+				t.Fatalf("expected agent id %s, got %s", agentID, req.GetAgentId())
+			}
+			return &agentsv1.CreateInstanceResponse{Instance: &agentsv1.AgentInstance{Meta: &agentsv1.EntityMeta{Id: instanceID.String()}, AgentId: agentID.String()}}, nil
+		},
+	}
+	authStub := &stubAuthorizationService{
+		t: t,
+		checkFn: func(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+			if req.GetTupleKey().GetRelation() == "can_initiate" && req.GetTupleKey().GetObject() != "agent:"+agentID.String() {
+				t.Fatalf("expected can_initiate on agent %s, got %s", agentID, req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, authStub, identityStub, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String(), "x-identity-type", "user", "x-organization-id", organizationID.String()))
+	_, err := srv.CreateThread(ctx, &threadsv1.CreateThreadRequest{Participants: []*threadsv1.ParticipantIdentifier{{Identifier: &threadsv1.ParticipantIdentifier_ParticipantId{ParticipantId: agentID.String()}}}})
+	if err != nil {
+		t.Fatalf("CreateThread returned error: %v", err)
+	}
+}
+
+func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
+	threadID := uuid.New()
+	messageID := uuid.New()
+	organizationID := uuid.New()
+	senderID := uuid.New()
+	userRecipientID := uuid.New()
+	agentInstanceID := uuid.New()
+	now := time.Now().UTC()
+	var fanoutCalled bool
+
+	storeStub := &stubThreadStore{
+		t: t,
+		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
+			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: senderID}, {ID: userRecipientID}, {ID: agentInstanceID}}}, nil
+		},
+		sendMessageFn: func(ctx context.Context, threadArg, senderArg uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID) (store.SendMessageResult, error) {
+			if !reflect.DeepEqual(messageRecipientIDs, []uuid.UUID{userRecipientID}) {
+				t.Fatalf("expected user/app message recipients only, got %v", messageRecipientIDs)
+			}
+			return store.SendMessageResult{Message: store.Message{ID: messageID, ThreadID: threadID, SenderID: senderID, Body: body, FileIDs: fileIDs, CreatedAt: now}, OrganizationID: organizationID, Recipients: messageRecipientIDs}, nil
+		},
+	}
+	identityStub := &stubIdentityResolver{
+		t: t,
+		typeBatchFn: func(ctx context.Context, req *identityv1.BatchGetIdentityTypesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetIdentityTypesResponse, error) {
+			entries := make([]*identityv1.IdentityTypeEntry, len(req.GetIdentityIds()))
+			for i, id := range req.GetIdentityIds() {
+				identityType := identityv1.IdentityType_IDENTITY_TYPE_USER
+				if id == agentInstanceID.String() {
+					identityType = identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE
+				}
+				entries[i] = &identityv1.IdentityTypeEntry{IdentityId: id, IdentityType: identityType}
+			}
+			return &identityv1.BatchGetIdentityTypesResponse{Entries: entries}, nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		fanoutFn: func(ctx context.Context, req *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error) {
+			fanoutCalled = true
+			if req.GetAgentInstanceId() != agentInstanceID.String() || req.GetThreadId() != threadID.String() || req.GetMessageId() != messageID.String() || req.GetSenderId() != senderID.String() {
+				t.Fatalf("unexpected fanout request: %+v", req)
+			}
+			return &agentsv1.FanoutInboxItemResponse{}, nil
+		},
+	}
+	notifierStub := &stubNotifier{t: t, publishFn: func(ctx context.Context, threadArg, messageArg uuid.UUID, recipients []uuid.UUID) error {
+		if !reflect.DeepEqual(recipients, []uuid.UUID{userRecipientID}) {
+			t.Fatalf("expected user notification recipients only, got %v", recipients)
+		}
+		return nil
+	}}
+
+	srv := New(storeStub, notifierStub, allowAuthStub(t), identityStub, agentsStub, nil)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", senderID.String()))
+	_, err := srv.SendMessage(ctx, &threadsv1.SendMessageRequest{ThreadId: threadID.String(), Body: "hi"})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+	if !fanoutCalled {
+		t.Fatal("expected agent instance fanout")
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2931,13 +2931,25 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 	senderID := uuid.New()
 	userRecipientID := uuid.New()
 	agentInstanceID := uuid.New()
+	claimID := uuid.New()
 	now := time.Now().UTC()
 	var fanoutCalled bool
+	var deliveredMarked bool
 
 	storeStub := &stubThreadStore{
 		t: t,
 		claimPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
-			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "hi", FileIDs: []uuid.UUID{}, ClaimID: uuid.New()}}, nil
+			if limit != agentInboxDeliveryLimit {
+				t.Fatalf("expected limit %d, got %d", agentInboxDeliveryLimit, limit)
+			}
+			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "claimed", FileIDs: []uuid.UUID{}, ClaimID: claimID}}, nil
+		},
+		markAgentInboxDeliveryDeliveredFn: func(ctx context.Context, messageArg, agentInstanceArg, claimArg uuid.UUID) error {
+			deliveredMarked = true
+			if messageArg != messageID || agentInstanceArg != agentInstanceID || claimArg != claimID {
+				t.Fatalf("unexpected delivered mark: %s %s %s", messageArg, agentInstanceArg, claimArg)
+			}
+			return nil
 		},
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
 			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: senderID}, {ID: userRecipientID}, {ID: agentInstanceID}}}, nil
@@ -2949,7 +2961,7 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 			if !reflect.DeepEqual(agentInstanceRecipientIDs, []uuid.UUID{agentInstanceID}) {
 				t.Fatalf("expected agent instance recipients, got %v", agentInstanceRecipientIDs)
 			}
-			return store.SendMessageResult{Message: store.Message{ID: messageID, ThreadID: threadID, SenderID: senderID, Body: body, FileIDs: fileIDs, CreatedAt: now}, OrganizationID: organizationID, Recipients: messageRecipientIDs, AgentInboxDeliveries: []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: body, FileIDs: fileIDs}}}, nil
+			return store.SendMessageResult{Message: store.Message{ID: messageID, ThreadID: threadID, SenderID: senderID, Body: body, FileIDs: fileIDs, CreatedAt: now}, OrganizationID: organizationID, Recipients: messageRecipientIDs, AgentInboxDeliveries: []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "unclaimed", FileIDs: fileIDs}}}, nil
 		},
 	}
 	identityStub := &stubIdentityResolver{
@@ -2973,6 +2985,9 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 			if req.GetAgentInstanceId() != agentInstanceID.String() || req.GetThreadId() != threadID.String() || req.GetMessageId() != messageID.String() || req.GetSenderId() != senderID.String() {
 				t.Fatalf("unexpected fanout request: %+v", req)
 			}
+			if req.GetBody() != "claimed" {
+				t.Fatalf("expected claimed outbox row body, got %q", req.GetBody())
+			}
 			return &agentsv1.FanoutInboxItemResponse{}, nil
 		},
 	}
@@ -2991,6 +3006,9 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 	}
 	if !fanoutCalled {
 		t.Fatal("expected agent instance fanout")
+	}
+	if !deliveredMarked {
+		t.Fatal("expected claimed delivery to be marked delivered")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,21 +23,21 @@ import (
 )
 
 type stubThreadStore struct {
-	t                                 *testing.T
-	createThreadFn                    func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
-	archiveThreadFn                   func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	degradeThreadFn                   func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	addParticipantFn                  func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
-	sendMessageFn                     func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
-	listPendingAgentInboxDeliveriesFn func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
-	markAgentInboxDeliveryDeliveredFn func(ctx context.Context, messageID, agentInstanceID uuid.UUID) error
-	markAgentInboxDeliveryFailedFn    func(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error
-	getThreadFn                       func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
-	listOrgThreadsFn                  func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
-	listMessagesFn                    func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
-	listUnackedFn                     func(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
-	unackedCountsFn                   func(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
-	ackMessagesFn                     func(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
+	t                                  *testing.T
+	createThreadFn                     func(ctx context.Context, organizationID uuid.UUID, participants []store.ParticipantInput) (store.Thread, error)
+	archiveThreadFn                    func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	degradeThreadFn                    func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	addParticipantFn                   func(ctx context.Context, threadID, participantID uuid.UUID, passive bool) (store.Thread, error)
+	sendMessageFn                      func(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, messageRecipientIDs []uuid.UUID, agentInstanceRecipientIDs []uuid.UUID) (store.SendMessageResult, error)
+	claimPendingAgentInboxDeliveriesFn func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error)
+	markAgentInboxDeliveryDeliveredFn  func(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID) error
+	markAgentInboxDeliveryFailedFn     func(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID, deliveryError string) error
+	getThreadFn                        func(ctx context.Context, threadID uuid.UUID) (store.Thread, error)
+	listOrgThreadsFn                   func(ctx context.Context, organizationID uuid.UUID, filter store.OrganizationThreadFilter, sort store.OrganizationThreadSort, pageSize int32, cursor *store.OrganizationThreadCursor) (store.OrganizationThreadListResult, error)
+	listMessagesFn                     func(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *store.MessageCursor, order store.MessageOrder) (store.MessageListResult, error)
+	listUnackedFn                      func(ctx context.Context, participantID uuid.UUID, threadID *uuid.UUID, pageSize int32, cursor *store.MessageCursor) (store.MessageListResult, error)
+	unackedCountsFn                    func(ctx context.Context, participantID uuid.UUID) (map[uuid.UUID]int32, error)
+	ackMessagesFn                      func(ctx context.Context, participantID uuid.UUID, messageIDs []uuid.UUID) (int32, error)
 }
 
 func (s *stubThreadStore) unexpectedCall(method string) {
@@ -85,28 +85,28 @@ func (s *stubThreadStore) SendMessage(ctx context.Context, threadID uuid.UUID, s
 	return s.sendMessageFn(ctx, threadID, senderID, body, fileIDs, messageRecipientIDs, agentInstanceRecipientIDs)
 }
 
-func (s *stubThreadStore) ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+func (s *stubThreadStore) ClaimPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
 	s.t.Helper()
-	if s.listPendingAgentInboxDeliveriesFn == nil {
+	if s.claimPendingAgentInboxDeliveriesFn == nil {
 		return nil, nil
 	}
-	return s.listPendingAgentInboxDeliveriesFn(ctx, limit)
+	return s.claimPendingAgentInboxDeliveriesFn(ctx, limit)
 }
 
-func (s *stubThreadStore) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error {
+func (s *stubThreadStore) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID) error {
 	s.t.Helper()
 	if s.markAgentInboxDeliveryDeliveredFn == nil {
 		return nil
 	}
-	return s.markAgentInboxDeliveryDeliveredFn(ctx, messageID, agentInstanceID)
+	return s.markAgentInboxDeliveryDeliveredFn(ctx, messageID, agentInstanceID, claimID)
 }
 
-func (s *stubThreadStore) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error {
+func (s *stubThreadStore) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID, deliveryError string) error {
 	s.t.Helper()
 	if s.markAgentInboxDeliveryFailedFn == nil {
 		return nil
 	}
-	return s.markAgentInboxDeliveryFailedFn(ctx, messageID, agentInstanceID, deliveryError)
+	return s.markAgentInboxDeliveryFailedFn(ctx, messageID, agentInstanceID, claimID, deliveryError)
 }
 
 func (s *stubThreadStore) GetThread(ctx context.Context, threadID uuid.UUID) (store.Thread, error) {
@@ -2936,6 +2936,9 @@ func TestSendMessageFansOutAgentInstancesOnly(t *testing.T) {
 
 	storeStub := &stubThreadStore{
 		t: t,
+		claimPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "hi", FileIDs: []uuid.UUID{}, ClaimID: uuid.New()}}, nil
+		},
 		getThreadFn: func(ctx context.Context, id uuid.UUID) (store.Thread, error) {
 			return store.Thread{ID: threadID, OrganizationID: &organizationID, Participants: []store.Participant{{ID: senderID}, {ID: userRecipientID}, {ID: agentInstanceID}}}, nil
 		},
@@ -3022,19 +3025,20 @@ func TestDrainPendingAgentInboxDeliveriesMarksDelivered(t *testing.T) {
 	threadID := uuid.New()
 	senderID := uuid.New()
 	agentInstanceID := uuid.New()
+	claimID := uuid.New()
 	var marked bool
 	storeStub := &stubThreadStore{
 		t: t,
-		listPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+		claimPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
 			if limit != agentInboxDeliveryLimit {
 				t.Fatalf("expected limit %d, got %d", agentInboxDeliveryLimit, limit)
 			}
-			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, Body: "hi"}}, nil
+			return []store.AgentInboxDelivery{{MessageID: messageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: agentInstanceID, ClaimID: claimID, Body: "hi"}}, nil
 		},
-		markAgentInboxDeliveryDeliveredFn: func(ctx context.Context, messageArg, agentInstanceArg uuid.UUID) error {
+		markAgentInboxDeliveryDeliveredFn: func(ctx context.Context, messageArg, agentInstanceArg, claimArg uuid.UUID) error {
 			marked = true
-			if messageArg != messageID || agentInstanceArg != agentInstanceID {
-				t.Fatalf("unexpected delivered mark: %s %s", messageArg, agentInstanceArg)
+			if messageArg != messageID || agentInstanceArg != agentInstanceID || claimArg != claimID {
+				t.Fatalf("unexpected delivered mark: %s %s %s", messageArg, agentInstanceArg, claimArg)
 			}
 			return nil
 		},
@@ -3055,5 +3059,77 @@ func TestDrainPendingAgentInboxDeliveriesMarksDelivered(t *testing.T) {
 	}
 	if !marked {
 		t.Fatal("expected delivered mark")
+	}
+}
+
+func TestDrainPendingAgentInboxDeliveriesContinuesAfterFailure(t *testing.T) {
+	failedMessageID := uuid.New()
+	succeededMessageID := uuid.New()
+	threadID := uuid.New()
+	senderID := uuid.New()
+	failedAgentInstanceID := uuid.New()
+	succeededAgentInstanceID := uuid.New()
+	failedClaimID := uuid.New()
+	succeededClaimID := uuid.New()
+	fanoutCalls := make([]uuid.UUID, 0, 2)
+	failedMarked := false
+	deliveredMarked := false
+	storeStub := &stubThreadStore{
+		t: t,
+		claimPendingAgentInboxDeliveriesFn: func(ctx context.Context, limit int32) ([]store.AgentInboxDelivery, error) {
+			return []store.AgentInboxDelivery{
+				{MessageID: failedMessageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: failedAgentInstanceID, ClaimID: failedClaimID, Body: "first"},
+				{MessageID: succeededMessageID, ThreadID: threadID, SenderID: senderID, AgentInstanceID: succeededAgentInstanceID, ClaimID: succeededClaimID, Body: "second"},
+			}, nil
+		},
+		markAgentInboxDeliveryFailedFn: func(ctx context.Context, messageArg, agentInstanceArg, claimArg uuid.UUID, deliveryError string) error {
+			failedMarked = true
+			if messageArg != failedMessageID || agentInstanceArg != failedAgentInstanceID || claimArg != failedClaimID {
+				t.Fatalf("unexpected failed mark: %s %s %s", messageArg, agentInstanceArg, claimArg)
+			}
+			if deliveryError == "" {
+				t.Fatal("expected delivery error")
+			}
+			return nil
+		},
+		markAgentInboxDeliveryDeliveredFn: func(ctx context.Context, messageArg, agentInstanceArg, claimArg uuid.UUID) error {
+			deliveredMarked = true
+			if messageArg != succeededMessageID || agentInstanceArg != succeededAgentInstanceID || claimArg != succeededClaimID {
+				t.Fatalf("unexpected delivered mark: %s %s %s", messageArg, agentInstanceArg, claimArg)
+			}
+			return nil
+		},
+	}
+	agentsStub := &stubAgentsService{
+		t: t,
+		fanoutFn: func(ctx context.Context, req *agentsv1.FanoutInboxItemRequest, opts ...grpc.CallOption) (*agentsv1.FanoutInboxItemResponse, error) {
+			messageID, err := uuid.Parse(req.GetMessageId())
+			if err != nil {
+				t.Fatalf("parse message id: %v", err)
+			}
+			fanoutCalls = append(fanoutCalls, messageID)
+			if messageID == failedMessageID {
+				return nil, status.Error(codes.Unavailable, "agents unavailable")
+			}
+			return &agentsv1.FanoutInboxItemResponse{}, nil
+		},
+	}
+
+	srv := New(storeStub, nil, nil, nil, agentsStub, nil)
+	err := srv.DrainPendingAgentInboxDeliveries(context.Background())
+	if err == nil {
+		t.Fatal("expected drain error")
+	}
+	if len(fanoutCalls) != 2 {
+		t.Fatalf("expected 2 fanout calls, got %d", len(fanoutCalls))
+	}
+	if fanoutCalls[0] != failedMessageID || fanoutCalls[1] != succeededMessageID {
+		t.Fatalf("unexpected fanout order: %v", fanoutCalls)
+	}
+	if !failedMarked {
+		t.Fatal("expected failed mark")
+	}
+	if !deliveredMarked {
+		t.Fatal("expected delivered mark after failure")
 	}
 }

--- a/internal/store/agent_inbox_deliveries.go
+++ b/internal/store/agent_inbox_deliveries.go
@@ -9,6 +9,31 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+const (
+	agentInboxDeliveryClaimTimeout = time.Minute
+	agentInboxDeliveryRetryDelay   = time.Minute
+)
+
+const claimPendingAgentInboxDeliveriesSQL = `WITH claimed AS (
+		SELECT message_id, agent_instance_id
+		FROM agent_inbox_deliveries
+		WHERE delivered_at IS NULL
+			AND (claimed_at IS NULL OR claimed_at < $2)
+			AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+		ORDER BY created_at ASC, message_id ASC, agent_instance_id ASC
+		LIMIT $1
+		FOR UPDATE SKIP LOCKED
+	)
+	UPDATE agent_inbox_deliveries d
+	SET claimed_at = NOW(), claim_id = $3, updated_at = NOW()
+	FROM claimed
+	WHERE d.message_id = claimed.message_id AND d.agent_instance_id = claimed.agent_instance_id
+	RETURNING d.message_id, d.agent_instance_id, d.thread_id, d.sender_id, d.body, d.file_ids, d.created_at, d.delivered_at, d.claimed_at, d.claim_id, d.next_attempt_at, d.attempts, d.last_error, d.updated_at`
+
+const markAgentInboxDeliveryDeliveredSQL = `UPDATE agent_inbox_deliveries SET delivered_at = $4, claimed_at = NULL, claim_id = NULL, next_attempt_at = NULL, updated_at = $4, last_error = NULL WHERE message_id = $1 AND agent_instance_id = $2 AND claim_id = $3 AND delivered_at IS NULL`
+
+const markAgentInboxDeliveryFailedSQL = `UPDATE agent_inbox_deliveries SET attempts = attempts + 1, claimed_at = NULL, claim_id = NULL, next_attempt_at = $5, last_error = $4, updated_at = $6 WHERE message_id = $1 AND agent_instance_id = $2 AND claim_id = $3 AND delivered_at IS NULL`
+
 type AgentInboxDelivery struct {
 	MessageID       uuid.UUID
 	AgentInstanceID uuid.UUID
@@ -18,20 +43,21 @@ type AgentInboxDelivery struct {
 	FileIDs         []uuid.UUID
 	CreatedAt       time.Time
 	DeliveredAt     *time.Time
+	ClaimedAt       *time.Time
+	ClaimID         uuid.UUID
+	NextAttemptAt   *time.Time
 	Attempts        int32
 	LastError       *string
 	UpdatedAt       time.Time
 }
 
-func (s *Store) ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]AgentInboxDelivery, error) {
+func (s *Store) ClaimPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]AgentInboxDelivery, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.pool.Query(ctx, `SELECT message_id, agent_instance_id, thread_id, sender_id, body, file_ids, created_at, delivered_at, attempts, last_error, updated_at
-		FROM agent_inbox_deliveries
-		WHERE delivered_at IS NULL
-		ORDER BY created_at ASC, message_id ASC, agent_instance_id ASC
-		LIMIT $1`, limit)
+	claimID := uuid.New()
+	claimBefore := time.Now().UTC().Add(-agentInboxDeliveryClaimTimeout)
+	rows, err := s.pool.Query(ctx, claimPendingAgentInboxDeliveriesSQL, limit, claimBefore, claimID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,22 +77,35 @@ func (s *Store) ListPendingAgentInboxDeliveries(ctx context.Context, limit int32
 	return deliveries, nil
 }
 
-func (s *Store) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error {
+func (s *Store) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID) error {
 	now := time.Now().UTC()
-	_, err := s.pool.Exec(ctx, `UPDATE agent_inbox_deliveries SET delivered_at = $3, updated_at = $3, last_error = NULL WHERE message_id = $1 AND agent_instance_id = $2`, messageID, agentInstanceID, now)
-	return err
+	cmd, err := s.pool.Exec(ctx, markAgentInboxDeliveryDeliveredSQL, messageID, agentInstanceID, claimID, now)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrAgentInboxDeliveryNotClaimed
+	}
+	return nil
 }
 
-func (s *Store) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error {
+func (s *Store) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID, claimID uuid.UUID, deliveryError string) error {
 	now := time.Now().UTC()
-	_, err := s.pool.Exec(ctx, `UPDATE agent_inbox_deliveries SET attempts = attempts + 1, last_error = $3, updated_at = $4 WHERE message_id = $1 AND agent_instance_id = $2 AND delivered_at IS NULL`, messageID, agentInstanceID, deliveryError, now)
-	return err
+	nextAttemptAt := now.Add(agentInboxDeliveryRetryDelay)
+	cmd, err := s.pool.Exec(ctx, markAgentInboxDeliveryFailedSQL, messageID, agentInstanceID, claimID, deliveryError, nextAttemptAt, now)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrAgentInboxDeliveryNotClaimed
+	}
+	return nil
 }
 
 func scanAgentInboxDelivery(row pgx.Row) (AgentInboxDelivery, error) {
 	var delivery AgentInboxDelivery
 	var fileIDs []string
-	if err := row.Scan(&delivery.MessageID, &delivery.AgentInstanceID, &delivery.ThreadID, &delivery.SenderID, &delivery.Body, &fileIDs, &delivery.CreatedAt, &delivery.DeliveredAt, &delivery.Attempts, &delivery.LastError, &delivery.UpdatedAt); err != nil {
+	if err := row.Scan(&delivery.MessageID, &delivery.AgentInstanceID, &delivery.ThreadID, &delivery.SenderID, &delivery.Body, &fileIDs, &delivery.CreatedAt, &delivery.DeliveredAt, &delivery.ClaimedAt, &delivery.ClaimID, &delivery.NextAttemptAt, &delivery.Attempts, &delivery.LastError, &delivery.UpdatedAt); err != nil {
 		return AgentInboxDelivery{}, err
 	}
 	parsedFileIDs, err := stringsToUUIDs(fileIDs)

--- a/internal/store/agent_inbox_deliveries.go
+++ b/internal/store/agent_inbox_deliveries.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type AgentInboxDelivery struct {
+	MessageID       uuid.UUID
+	AgentInstanceID uuid.UUID
+	ThreadID        uuid.UUID
+	SenderID        uuid.UUID
+	Body            string
+	FileIDs         []uuid.UUID
+	CreatedAt       time.Time
+	DeliveredAt     *time.Time
+	Attempts        int32
+	LastError       *string
+	UpdatedAt       time.Time
+}
+
+func (s *Store) ListPendingAgentInboxDeliveries(ctx context.Context, limit int32) ([]AgentInboxDelivery, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx, `SELECT message_id, agent_instance_id, thread_id, sender_id, body, file_ids, created_at, delivered_at, attempts, last_error, updated_at
+		FROM agent_inbox_deliveries
+		WHERE delivered_at IS NULL
+		ORDER BY created_at ASC, message_id ASC, agent_instance_id ASC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	deliveries := make([]AgentInboxDelivery, 0)
+	for rows.Next() {
+		delivery, err := scanAgentInboxDelivery(rows)
+		if err != nil {
+			return nil, err
+		}
+		deliveries = append(deliveries, delivery)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return deliveries, nil
+}
+
+func (s *Store) MarkAgentInboxDeliveryDelivered(ctx context.Context, messageID, agentInstanceID uuid.UUID) error {
+	now := time.Now().UTC()
+	_, err := s.pool.Exec(ctx, `UPDATE agent_inbox_deliveries SET delivered_at = $3, updated_at = $3, last_error = NULL WHERE message_id = $1 AND agent_instance_id = $2`, messageID, agentInstanceID, now)
+	return err
+}
+
+func (s *Store) MarkAgentInboxDeliveryFailed(ctx context.Context, messageID, agentInstanceID uuid.UUID, deliveryError string) error {
+	now := time.Now().UTC()
+	_, err := s.pool.Exec(ctx, `UPDATE agent_inbox_deliveries SET attempts = attempts + 1, last_error = $3, updated_at = $4 WHERE message_id = $1 AND agent_instance_id = $2 AND delivered_at IS NULL`, messageID, agentInstanceID, deliveryError, now)
+	return err
+}
+
+func scanAgentInboxDelivery(row pgx.Row) (AgentInboxDelivery, error) {
+	var delivery AgentInboxDelivery
+	var fileIDs []string
+	if err := row.Scan(&delivery.MessageID, &delivery.AgentInstanceID, &delivery.ThreadID, &delivery.SenderID, &delivery.Body, &fileIDs, &delivery.CreatedAt, &delivery.DeliveredAt, &delivery.Attempts, &delivery.LastError, &delivery.UpdatedAt); err != nil {
+		return AgentInboxDelivery{}, err
+	}
+	parsedFileIDs, err := stringsToUUIDs(fileIDs)
+	if err != nil {
+		return AgentInboxDelivery{}, fmt.Errorf("parse file ids: %w", err)
+	}
+	delivery.FileIDs = parsedFileIDs
+	return delivery, nil
+}

--- a/internal/store/agent_inbox_deliveries_test.go
+++ b/internal/store/agent_inbox_deliveries_test.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClaimPendingAgentInboxDeliveriesQueryAtomicallyClaimsRows(t *testing.T) {
+	if !strings.Contains(claimPendingAgentInboxDeliveriesSQL, "FOR UPDATE SKIP LOCKED") {
+		t.Fatalf("expected claim query to lock pending rows, got %s", claimPendingAgentInboxDeliveriesSQL)
+	}
+	if !strings.Contains(claimPendingAgentInboxDeliveriesSQL, "UPDATE agent_inbox_deliveries") {
+		t.Fatalf("expected claim query to update claimed rows, got %s", claimPendingAgentInboxDeliveriesSQL)
+	}
+	if !strings.Contains(claimPendingAgentInboxDeliveriesSQL, "SET claimed_at = NOW(), claim_id = $3") {
+		t.Fatalf("expected claim query to assign claim fields, got %s", claimPendingAgentInboxDeliveriesSQL)
+	}
+	if !strings.Contains(claimPendingAgentInboxDeliveriesSQL, "claimed_at IS NULL OR claimed_at < $2") {
+		t.Fatalf("expected claim query to reclaim stale rows, got %s", claimPendingAgentInboxDeliveriesSQL)
+	}
+	if !strings.Contains(claimPendingAgentInboxDeliveriesSQL, "next_attempt_at IS NULL OR next_attempt_at <= NOW()") {
+		t.Fatalf("expected claim query to skip deferred retries, got %s", claimPendingAgentInboxDeliveriesSQL)
+	}
+}
+
+func TestAgentInboxDeliveryMarkQueriesRequireClaimOwnership(t *testing.T) {
+	for name, query := range map[string]string{
+		"delivered": markAgentInboxDeliveryDeliveredSQL,
+		"failed":    markAgentInboxDeliveryFailedSQL,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(query, "claim_id = $3") {
+				t.Fatalf("expected %s query to require claim ownership, got %s", name, query)
+			}
+			if !strings.Contains(query, "delivered_at IS NULL") {
+				t.Fatalf("expected %s query to update only pending rows, got %s", name, query)
+			}
+		})
+	}
+}
+
+func TestAgentInboxDeliveryFailureDefersRetry(t *testing.T) {
+	if !strings.Contains(markAgentInboxDeliveryFailedSQL, "next_attempt_at = $5") {
+		t.Fatalf("expected failed query to defer retry, got %s", markAgentInboxDeliveryFailedSQL)
+	}
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -12,12 +12,13 @@ import (
 )
 
 type SendMessageResult struct {
-	Message        Message
-	OrganizationID uuid.UUID
-	Recipients     []uuid.UUID
+	Message              Message
+	OrganizationID       uuid.UUID
+	Recipients           []uuid.UUID
+	AgentInboxDeliveries []AgentInboxDelivery
 }
 
-func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, recipients []uuid.UUID) (SendMessageResult, error) {
+func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, recipients []uuid.UUID, agentInstanceRecipients []uuid.UUID) (SendMessageResult, error) {
 	var result SendMessageResult
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		thread, err := loadThreadRow(ctx, tx, threadID, true)
@@ -49,6 +50,26 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 				return err
 			}
 		}
+		agentInboxDeliveries := make([]AgentInboxDelivery, len(agentInstanceRecipients))
+		if len(agentInstanceRecipients) > 0 {
+			rows := make([][]any, len(agentInstanceRecipients))
+			for i, agentInstanceID := range agentInstanceRecipients {
+				rows[i] = []any{messageID, agentInstanceID, threadID, senderID, body, fileIDArray, now, now}
+				agentInboxDeliveries[i] = AgentInboxDelivery{
+					MessageID:       messageID,
+					AgentInstanceID: agentInstanceID,
+					ThreadID:        threadID,
+					SenderID:        senderID,
+					Body:            body,
+					FileIDs:         fileIDs,
+					CreatedAt:       now,
+					UpdatedAt:       now,
+				}
+			}
+			if _, err := tx.CopyFrom(ctx, pgx.Identifier{"agent_inbox_deliveries"}, []string{"message_id", "agent_instance_id", "thread_id", "sender_id", "body", "file_ids", "created_at", "updated_at"}, pgx.CopyFromRows(rows)); err != nil {
+				return err
+			}
+		}
 		if _, err := tx.Exec(ctx, `UPDATE threads SET updated_at = $2, message_count = message_count + 1 WHERE id = $1`, threadID, now); err != nil {
 			return err
 		}
@@ -61,8 +82,9 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 				FileIDs:   fileIDs,
 				CreatedAt: now,
 			},
-			OrganizationID: organizationID,
-			Recipients:     recipients,
+			OrganizationID:       organizationID,
+			Recipients:           recipients,
+			AgentInboxDeliveries: agentInboxDeliveries,
 		}
 		return nil
 	})

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -17,7 +17,7 @@ type SendMessageResult struct {
 	Recipients     []uuid.UUID
 }
 
-func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID) (SendMessageResult, error) {
+func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, body string, fileIDs []uuid.UUID, recipients []uuid.UUID) (SendMessageResult, error) {
 	var result SendMessageResult
 	err := s.runTx(ctx, func(tx pgx.Tx) error {
 		thread, err := loadThreadRow(ctx, tx, threadID, true)
@@ -40,12 +40,6 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 		if _, err := tx.Exec(ctx, `INSERT INTO messages (id, thread_id, sender_id, body, file_ids, created_at) VALUES ($1, $2, $3, $4, $5, $6)`, messageID, threadID, senderID, body, fileIDArray, now); err != nil {
 			return err
 		}
-		recipients, err := loadRecipients(ctx, tx, threadID, senderID)
-		if err != nil {
-			return err
-		}
-		// Passive participants still receive message notifications; workload
-		// triggers are handled downstream.
 		if len(recipients) > 0 {
 			rows := make([][]any, len(recipients))
 			for i, recipientID := range recipients {
@@ -76,27 +70,6 @@ func (s *Store) SendMessage(ctx context.Context, threadID, senderID uuid.UUID, b
 		return SendMessageResult{}, err
 	}
 	return result, nil
-}
-
-func loadRecipients(ctx context.Context, q queryer, threadID, senderID uuid.UUID) ([]uuid.UUID, error) {
-	rows, err := q.Query(ctx, `SELECT participant_id FROM thread_participants WHERE thread_id = $1 AND participant_id <> $2 ORDER BY participant_id ASC`, threadID, senderID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	recipients := []uuid.UUID{}
-	for rows.Next() {
-		var recipientID uuid.UUID
-		if err := rows.Scan(&recipientID); err != nil {
-			return nil, err
-		}
-		recipients = append(recipients, recipientID)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return recipients, nil
 }
 
 func (s *Store) ListMessages(ctx context.Context, threadID uuid.UUID, pageSize int32, cursor *MessageCursor, order MessageOrder) (MessageListResult, error) {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -8,11 +8,12 @@ import (
 )
 
 var (
-	ErrThreadNotFound            = errors.New("thread not found")
-	ErrThreadArchived            = errors.New("thread is archived")
-	ErrThreadDegraded            = errors.New("thread is degraded")
-	ErrThreadOrganizationMissing = errors.New("thread organization_id missing")
-	ErrParticipantNotInThread    = errors.New("participant not in thread")
+	ErrThreadNotFound               = errors.New("thread not found")
+	ErrThreadArchived               = errors.New("thread is archived")
+	ErrThreadDegraded               = errors.New("thread is degraded")
+	ErrThreadOrganizationMissing    = errors.New("thread organization_id missing")
+	ErrParticipantNotInThread       = errors.New("participant not in thread")
+	ErrAgentInboxDeliveryNotClaimed = errors.New("agent inbox delivery not claimed")
 )
 
 type ThreadStatus int16

--- a/migrations/0005_agent_inbox_delivery_outbox.sql
+++ b/migrations/0005_agent_inbox_delivery_outbox.sql
@@ -1,0 +1,18 @@
+CREATE TABLE agent_inbox_deliveries (
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    agent_instance_id UUID NOT NULL,
+    thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    sender_id UUID NOT NULL,
+    body TEXT NOT NULL,
+    file_ids TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at TIMESTAMPTZ,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (message_id, agent_instance_id)
+);
+
+CREATE INDEX idx_agent_inbox_deliveries_pending
+    ON agent_inbox_deliveries (created_at, message_id, agent_instance_id)
+    WHERE delivered_at IS NULL;

--- a/migrations/0005_agent_inbox_delivery_outbox.sql
+++ b/migrations/0005_agent_inbox_delivery_outbox.sql
@@ -7,6 +7,9 @@ CREATE TABLE agent_inbox_deliveries (
     file_ids TEXT[] NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     delivered_at TIMESTAMPTZ,
+    claimed_at TIMESTAMPTZ,
+    claim_id UUID,
+    next_attempt_at TIMESTAMPTZ,
     attempts INTEGER NOT NULL DEFAULT 0,
     last_error TEXT,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -15,4 +18,4 @@ CREATE TABLE agent_inbox_deliveries (
 
 CREATE INDEX idx_agent_inbox_deliveries_pending
     ON agent_inbox_deliveries (created_at, message_id, agent_instance_id)
-    WHERE delivered_at IS NULL;
+    WHERE delivered_at IS NULL AND claimed_at IS NULL;


### PR DESCRIPTION
## Summary
- Rewrites agent-class thread participants to fresh agent instances through Agents `CreateInstance` and persists instance IDs.
- Resolves existing `agent_instance` participants through Agents `GetInstance` for class-scoped `can_initiate` checks.
- Sends `message_recipients` only for user/app-style recipients and fans out agent-instance recipients through Agents `FanoutInboxItem`.
- Rejects passive participant requests and keeps initiator participants active.
- Includes nickname instance suffix rendering in organization thread responses.

Closes #161

## Validation
- `PATH=/root/go/bin:$PATH buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1` - passed
- `go test ./...` - passed: 3 packages passed, 6 packages had no test files
- `go vet ./...` - passed with no errors
- `go build ./...` - passed with no errors
- `git diff --check` - passed with no whitespace errors
- `devspace run test:e2e` - blocked before tests: DevSpace rejects command name `test:e2e` with regex `^(([a-z0-9][a-z0-9\-]*[a-z0-9])|([a-z0-9]))$`
- `devspace run-pipeline test:e2e` - blocked before tests: no valid kube config for context `incluster`
- `go test -tags e2e ./test/e2e` - compiled and ran, failed dialing default `threads:50051` with `context deadline exceeded` because no local Threads service is running