### PR TITLE
fix(devspace): make dev work against a standalone install

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -160,9 +160,10 @@ hooks:
 dev:
   threads:
     namespace: ${THREADS_NAMESPACE}
+    # Name only: the instance label is the Helm release, which is threads for a
+    # standalone install and agyn-platform under the umbrella chart.
     labelSelector:
       app.kubernetes.io/name: threads
-      app.kubernetes.io/instance: threads
     containers:
       threads:
         container: threads

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -49,6 +49,18 @@ functions:
             - name: threads
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
               workingDir: /opt/app/data
+              # The dev container generates and compiles before it listens,
+              # which takes minutes. Liveness would restart it mid-build, so it
+              # goes; readiness stays -- without it the pod reports Ready while
+              # nothing is on the port and callers get connection refused -- but
+              # with a threshold long enough to cover a cold build.
+              livenessProbe: null
+              startupProbe: null
+              readinessProbe:
+                tcpSocket:
+                  port: 50051
+                periodSeconds: 10
+                failureThreshold: 120
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -49,18 +49,15 @@ functions:
             - name: threads
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
               workingDir: /opt/app/data
-              # The dev container generates and compiles before it listens,
-              # which takes minutes. Liveness would restart it mid-build, so it
-              # goes; readiness stays -- without it the pod reports Ready while
-              # nothing is on the port and callers get connection refused -- but
-              # with a threshold long enough to cover a cold build.
+              # All three go. The container generates and compiles before it
+              # listens, so liveness would restart it mid-build -- and devspace
+              # will not start syncing until the pod is ready, so a readiness
+              # probe on the port deadlocks: no source, so no listener, so never
+              # ready, so no sync. The dev pipeline waits on port 50051 itself
+              # once the sync is through.
               livenessProbe: null
               startupProbe: null
-              readinessProbe:
-                tcpSocket:
-                  port: 50051
-                periodSeconds: 10
-                failureThreshold: 120
+              readinessProbe: null
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -66,10 +66,22 @@ functions:
                 - -c
                 - |
                   set -eu
+                  # devspace only starts syncing once the pod is up, and waits
+                  # for it to be ready first -- so exiting here restarts the
+                  # container and the sync never lands. Wait for the whole set
+                  # generation needs, not just go.mod, or buf runs on a half
+                  # synced tree.
                   elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
+                  until [ -f /opt/app/data/go.mod ] \
+                    && [ -f /opt/app/data/go.sum ] \
+                    && [ -f /opt/app/data/buf.gen.yaml ] \
+                    && [ -f /opt/app/data/buf.yaml ]; do
                     sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                    if [ "$elapsed" -ge 600 ]; then
+                      echo "ERROR: sync timeout waiting for source files" >&2
+                      ls -la /opt/app/data >&2 || true
+                      exit 1
+                    fi
                   done
                   buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/metering/v1 --path agynio/api/authorization/v1 --path agynio/api/agents/v1
                   exec go run ./cmd/threads

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,9 +25,16 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'threads' not found in argocd namespace."
     fi
+  threads_deployment: |-
+    # The release name varies by install: the umbrella chart names it
+    # threads-threads, a standalone install just threads. Resolve it by label
+    # rather than guessing.
+    kubectl get deployment -n ${THREADS_NAMESPACE} \
+      -l app.kubernetes.io/name=threads \
+      -o jsonpath='{.items[0].metadata.name}'
   patch_deployment: |-
     echo "Patching threads deployment for DevSpace..."
-    kubectl patch deployment threads-threads -n ${THREADS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment "$(threads_deployment)" -n ${THREADS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -94,8 +101,8 @@ deployments:
           app.kubernetes.io/name: threads-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -127,7 +134,7 @@ pipelines:
         stop_dev threads
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &


### PR DESCRIPTION
`devspace dev` could not run at all against the local VM.

- **devspace 6.3.20 rejects a colon in pipeline and command names**, so the config failed to parse before doing anything: `pipelines.test:e2e has to match the following regex`. agents-orchestrator's e2e workflow had been rewriting `test:e2e` → `test-e2e` in place to get past this; renaming it here removes the need.
- **The deployment was patched by the hardcoded name `threads-threads`**, which only exists when the umbrella chart installs it. A standalone install names it `threads`. It's now resolved by label, which covers both.