### PR TITLE
fix: forward the caller identity when creating an instance

### DIFF
--- a/internal/server/default_thread_test.go
+++ b/internal/server/default_thread_test.go
@@ -113,3 +113,37 @@ func TestResolveSendThreadRejectsAMalformedThread(t *testing.T) {
 		t.Fatalf("expected InvalidArgument, got %v", err)
 	}
 }
+
+// Agents checks that the caller can initiate the class, so the identity of
+// whoever is adding the agent has to reach it. Called as Threads -- with no
+// identity at all -- CreateInstance refuses and class-on-add fails outright.
+func TestCreateAgentInstanceForwardsTheCallerIdentity(t *testing.T) {
+	callerID := uuid.New()
+	originThreadID := uuid.New()
+	instanceID := uuid.New()
+	var seen metadata.MD
+	agents := &stubAgentsService{
+		t: t,
+		createFn: func(ctx context.Context, req *agentsv1.CreateInstanceRequest, _ ...grpc.CallOption) (*agentsv1.CreateInstanceResponse, error) {
+			seen, _ = metadata.FromOutgoingContext(ctx)
+			if got := req.GetContext().GetThreadId(); got != originThreadID.String() {
+				t.Fatalf("expected the origin thread %s, got %q", originThreadID, got)
+			}
+			return &agentsv1.CreateInstanceResponse{Instance: &agentsv1.AgentInstance{
+				Meta: &agentsv1.EntityMeta{Id: instanceID.String()},
+			}}, nil
+		},
+	}
+	srv := New(nil, nil, nil, nil, agents, nil)
+
+	got, err := srv.createAgentInstance(identityContext(callerID, "user"), uuid.New(), originThreadID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != instanceID {
+		t.Fatalf("expected %s, got %s", instanceID, got)
+	}
+	if values := seen.Get(identityIDMetadataKey); len(values) != 1 || values[0] != callerID.String() {
+		t.Fatalf("expected the caller identity to be forwarded, got %v", values)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -411,11 +411,19 @@ func (s *Server) createAgentInstance(ctx context.Context, agentID uuid.UUID, ori
 	if s.agents == nil {
 		return uuid.UUID{}, status.Error(codes.Internal, "agents service not configured")
 	}
+	// Forwarded rather than called as Threads: the instance is created on
+	// behalf of whoever is adding the agent, and Agents checks that principal
+	// can initiate the class. Called without it, CreateInstance refuses --
+	// which made class-on-add fail outright.
+	identityCtx, err := identityClientContext(ctx)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
 	request := &agentsv1.CreateInstanceRequest{AgentId: agentID.String()}
 	if originThreadID != uuid.Nil {
 		request.Context = &agentsv1.CreateInstanceContext{ThreadId: protoString(originThreadID.String())}
 	}
-	response, err := s.agents.CreateInstance(ctx, request)
+	response, err := s.agents.CreateInstance(identityCtx, request)
 	if err != nil {
 		return uuid.UUID{}, status.Errorf(codes.Internal, "create agent instance: %v", err)
 	}


### PR DESCRIPTION
Adding an agent class to a thread creates an instance for it, and Agents checks that the caller can initiate that class. Threads called `CreateInstance` with no identity metadata at all, so Agents refused:

```
create agent instance: rpc error: code = Unauthenticated
desc = identity not available: x-identity-id not found in metadata
```

Class-on-add is the path the whole agent instance feature depends on, so it failed outright. Found running the go-core suite against the local VM — `TestWorkloadStartsOnUnackedMessage`.

The identity is forwarded rather than the call being made as Threads: the instance is created on behalf of whoever is adding the agent, so the check stays on that principal instead of moving to a peer service. `identityClientContext` already existed for exactly this and three other call sites use it.