### PR TITLE
chore: remove the ArgoCD sync dance

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -5,26 +5,6 @@ vars:
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
-  disable_argocd_sync: |-
-    if kubectl get application threads -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for threads..."
-      kubectl patch application threads -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'threads' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application threads -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for threads..."
-      kubectl patch application threads -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    else
-      echo "WARNING: ArgoCD Application 'threads' not found in argocd namespace."
-    fi
   threads_deployment: |-
     # The release name varies by install: the umbrella chart names it
     # threads-threads, a standalone install just threads. Resolve it by label
@@ -132,7 +112,6 @@ pipelines:
         short: w
         description: "Keep DevSpace running and stream logs"
     run: |-
-      disable_argocd_sync
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace threads
@@ -170,13 +149,6 @@ pipelines:
       exit $EXIT_CODE
 
 hooks:
-  - name: restore-argocd-auto-sync
-    events:
-      - after:dev:threads
-    command: bash
-    args:
-      - -c
-      - *restore_argocd_sync
 
 dev:
   threads:


### PR DESCRIPTION
ArgoCD went away with bootstrap. Disabling its auto-sync before a source deploy and restoring it after has had nothing to disable or restore since the platform moved to the VM — every run printed `WARNING: ArgoCD Application not found in argocd namespace` and carried on.

Removes the `disable_argocd_sync` / `restore_argocd_sync` functions, their call sites, the `restore-argocd` pipeline and the `after:dev` hook.

Part of removing the E2E workflow’s build-time source patches: three of them existed only to inject a "skip the ArgoCD restore in CI" branch into this file.